### PR TITLE
Change api call hooks to context api hooks

### DIFF
--- a/client/src/components/AdminPage/GuardedRoute.tsx
+++ b/client/src/components/AdminPage/GuardedRoute.tsx
@@ -12,13 +12,13 @@ type Props =  {
 };
 
 function GuardedRoute({ children, ...rest }: Props) {
-  const { authToken, setAuthToken } = useAuthToken();
+  const authToken = useAuthToken();
 
   return (
     <Route {...rest} render={(props) => (
-      authToken ? children : (
+      authToken.value ? children : (
         <Login
-          onLoginSuccess={setAuthToken}
+          onLoginSuccess={authToken.set}
           onLoginFail={(e) => console.log(e)}
         />
       )

--- a/client/src/components/AdminPage/components/EventAdmin/EventAdmin.tsx
+++ b/client/src/components/AdminPage/components/EventAdmin/EventAdmin.tsx
@@ -32,19 +32,19 @@ function EventAdmin() {
   const { url } = useRouteMatch();
   const event = useEvent(eventId);
 
-  if (!event) return <Spinner />;
+  if (!event.value) return <Spinner />;
 
   const subroutes: RouteList = [
-    ['home', 'Home', () => <Home event={event} />],
-    ['registrations', 'Registrations', () => <Registrations event={event} />],
-    ['lodging', 'Lodging', () => <Lodging event={event} />],
-    ['reports', 'Reports', () => <Reports event={event} />],
-    ['settings', 'Settings', () => <Settings event={event} />],
+    ['home', 'Home', () => <Home event={event.value} />],
+    ['registrations', 'Registrations', () => <Registrations event={event.value} />],
+    ['lodging', 'Lodging', () => <Lodging event={event.value} />],
+    ['reports', 'Reports', () => <Reports event={event.value} />],
+    ['settings', 'Settings', () => <Settings event={event.value} />],
   ];
 
   return (
     <Container><Row className="justify-content-md-center"><Col>
-      <NavBar routes={subroutes} title={event.name} homeUrl={`${url}/home`} />
+      <NavBar routes={subroutes} title={event.value.name} homeUrl={`${url}/home`} />
       <Switch>
         <Redirect from="/:url*(/+)" to={pathname.slice(0, -1)} />
         {

--- a/client/src/components/AdminPage/components/EventChooser.tsx
+++ b/client/src/components/AdminPage/components/EventChooser.tsx
@@ -10,13 +10,13 @@ function EventChooser() {
   const { pathname } = useLocation();
   const events = useEvents();
 
-  if (!events.length) return <Spinner />;
+  if (!events.value.length) return <Spinner />;
 
   return (
     <Container><Row className="justify-content-md-center"><Col>
       <ul>
         {
-          events.map(
+          events.value.map(
             (event) => (
               <li key={event.id}>
                 <Link to={`${pathname}/${event.id}`}>

--- a/client/src/components/AdminPage/components/OrganizationChooser.tsx
+++ b/client/src/components/AdminPage/components/OrganizationChooser.tsx
@@ -10,13 +10,13 @@ function OrganizationChooser() {
   const { pathname } = useLocation();
   const organizations = useOrganizations();
 
-  if (!organizations.length) return <Spinner />;
+  if (!organizations.value.length) return <Spinner />;
 
   return (
     <Container><Row className="justify-content-md-center"><Col>
       <ul>
         {
-          organizations.map(
+          organizations.value.map(
             (org) => (
               <li key={org.id}>
                 <Link to={`${pathname}/${org.id}/event`}>{org.name}</Link>

--- a/client/src/components/App/App.tsx
+++ b/client/src/components/App/App.tsx
@@ -1,28 +1,162 @@
 import React, { Suspense } from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import Spinner from '../Spinner';
+import {
+  OrganizationsContext,
+  EventsContext,
+  AuthContext,
+} from '../AdminPage/hooks';
 
 import Splash from './Splash';
 
 const AdminPage = React.lazy(() => import('../AdminPage'));
 const RegisterPage = React.lazy(() => import('../RegisterPage'));
 
-const App = () => (
-    <Router>
-      <Route path="/" exact={true}>
-        <Splash />
-      </Route>
-      <Route path="/events/:eventId/register">
-        <Suspense fallback={<Spinner />}>
-          <RegisterPage />
-        </Suspense>
-      </Route>
-      <Route path="/admin">
-        <Suspense fallback={<Spinner />}>
-          <AdminPage />
-        </Suspense>
-      </Route>
-    </Router>
-);
+type State = {
+  authToken: {
+    set: (value: string) => void,
+    value: string,
+  },
+  events: {
+    poll: () => Promise<any>,
+    value: Array<ApiEvent>,
+  },
+  organizations: {
+    poll: () => Promise<any>,
+    value: Array<ApiOrganization>,
+  },
+}
+
+class App extends React.Component<{}, State> {
+  constructor(props: {}) {
+    super(props);
+
+    window.addEventListener('storage', this.authLocalStorageListener);
+
+    this.state = {
+      authToken: {
+        set: this.setAuthToken,
+        value: localStorage.getItem('AUTH_TOKEN') || ''
+      },
+      events: {
+        poll: this.pollEvents,
+        value: [],
+      },
+      organizations: {
+        poll: this.pollOrganizations,
+        value: [],
+      },
+    };
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('storage', this.authLocalStorageListener);
+  }
+
+  setAuthToken = (value: string) => {
+    localStorage.setItem('AUTH_TOKEN', value);
+  }
+
+  authLocalStorageListener = (event: StorageEvent) => {
+    if (event.storageArea !== localStorage) return;
+    const newAuthToken = localStorage.getItem('AUTH_TOKEN') || '';
+    if (newAuthToken === this.state.authToken.value) return;
+
+    const authToken = {
+      set: this.setAuthToken,
+      value: newAuthToken,
+    };
+
+    this.setState({ authToken });
+  }
+
+  pollOrganizations = async () => {
+    const { authToken } = this.state;
+
+    try {
+      const response = await fetch(
+        '/api/organizations/',
+        {
+          method: 'GET',
+          headers: new Headers({
+            'Authorization': `Token ${authToken.value}`, 
+            'Content-Type': 'application/json'
+          }),
+        },
+      );
+
+      const value = await response.json();
+
+      const organizations = {
+        poll: this.pollOrganizations,
+        value,
+      };
+
+      this.setState({ organizations });
+    } catch (e) {
+      console.error('error getting Organizations', e);
+    }
+  }
+
+  pollEvents = async () => {
+    const { authToken } = this.state;
+
+    try {
+      const response = await fetch(
+        '/api/events/',
+        {
+          method: 'GET',
+          headers: new Headers({
+            'Authorization': `Token ${authToken.value}`, 
+            'Content-Type': 'application/json'
+          }),
+        },
+      );
+
+      const value = await response.json();
+
+      this.setState({
+        events: {
+          poll: this.pollEvents,
+          value,
+        },
+      });
+    } catch (e) {
+      console.error('error getting Events', e);
+    }
+  }
+
+  router() {
+    return (
+      <Router>
+        <Route path="/" exact={true}>
+          <Splash />
+        </Route>
+        <Route path="/events/:eventId/register">
+          <Suspense fallback={<Spinner />}>
+            <RegisterPage />
+          </Suspense>
+        </Route>
+        <Route path="/admin">
+          <Suspense fallback={<Spinner />}>
+            <AdminPage />
+          </Suspense>
+        </Route>
+      </Router>
+    );
+  }
+
+  render() {
+    return (
+      <OrganizationsContext.Provider value={this.state.organizations}>
+        <EventsContext.Provider value={this.state.events}>
+          <AuthContext.Provider value={this.state.authToken}>
+            {this.router()}
+          </AuthContext.Provider>
+        </EventsContext.Provider>
+      </OrganizationsContext.Provider>
+    );
+  }
+}
 
 export default App;


### PR DESCRIPTION
After talking with @evinism this evening, he mentioned that the context API is really meant for what I'm using hooks for, since the context api is used to persist global state, similar to redux.

This implements that.