### PR TITLE
Fix error in python logic

### DIFF
--- a/server/camphoric/pricing.py
+++ b/server/camphoric/pricing.py
@@ -71,7 +71,7 @@ def calculate_price(registration, campers):
             value = jsonLogic(camper_component["exp"], data)
             camper_results[var] = value
             if isinstance(value, numbers.Number):
-                results[var] += value
+                results[var] = (results[var] or 0) + value
             data[var] = value
 
         results['campers'].append(camper_results)


### PR DESCRIPTION
I did my best to fix this, hopefully this looks kosher...

I was getting this when trying to register with family week:


Request Method: | POST
-- | --
http://localhost:8000/api/events/1/register
3.1.3
TypeError
unsupported operand type(s) for +: 'NoneType' and 'int'
/Users/will/Sources/camphoric/server/camphoric/pricing.py, line 74, in calculate_price
/Users/will/.local/share/virtualenvs/server-BDZILzX2/bin/python
3.9.0
['/Users/will/Sources/camphoric/server',  '/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python39.zip',  '/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9',  '/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/lib-dynload',  '/Users/will/.local/share/virtualenvs/server-BDZILzX2/lib/python3.9/site-packages']
Sun, 13 Dec 2020 01:18:48 +0000

