### PR TITLE
 Revert to Form from '@rjsf/core' for RegisterPage 

### DIFF
--- a/client/src/components/RegisterPage/RegisterPage.tsx
+++ b/client/src/components/RegisterPage/RegisterPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { IChangeEvent, UiSchema } from '@rjsf/core';
-import Form from '@rjsf/bootstrap-4';
+import Form from '@rjsf/core';
 import { JSONSchema7 } from 'json-schema';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { Container, Row, Col } from 'react-bootstrap';

--- a/data/lark/loadData.mjs
+++ b/data/lark/loadData.mjs
@@ -73,7 +73,7 @@ const event = {
 if (existingEvent) {
 	event.id = existingEvent.id;
 }
-response = await fetch(`${urlBase}/api/events/${event.id}/`, {
+response = await fetch(`${urlBase}/api/events/${existingEvent ? `${event.id}/` : ''}`, {
 	method: existingEvent ? 'PUT' : 'POST',
 	headers: {
 		'Authorization': `Token ${token}`,


### PR DESCRIPTION
The Form component from '@rjsf/bootstrap-4' broke our bootstrap-3 styling and customized DescriptionField that renders HTML, causing the Lark reg form to fail to render. This fixes that by reverting to Form from '@rjsf/core' for now for the RegistrationPage.

Also includes a fix for a bug in the lark loadData script.