### PR TITLE
Implement cookie-based login

### DIFF
--- a/server/Pipfile
+++ b/server/Pipfile
@@ -5,6 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 freezegun = "*"
+flake8 = "*"
 
 [packages]
 django = "*"

--- a/server/Pipfile.lock
+++ b/server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7bd6888db0c61da4efe589cd148862c47fb2ab55518f430885c1cb1dce12d8ef"
+            "sha256": "e90337ec0a7e73aa1144009639954995de02d76bf32610b5baaf0e9e129ccca3"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -47,11 +47,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:95b318319d6997bac3595517101ad9cc83fe5672ac498ba48d1a410f47afecd2",
-                "sha256:e93c93565005b37ddebf2396b4dc4b6913c1838baa82efdfb79acedd5816c240"
+                "sha256:42573831292029639b798fe4d3812996bfe4ff3275f04566da90764daec011a5",
+                "sha256:f6d2c4069c9b9bfac03bedff927ea1f9e0d29e34525cec8a68fd28eb2a8df7af"
             ],
             "index": "pypi",
-            "version": "==3.2.7"
+            "version": "==3.2.8"
         },
         "django-environ": {
             "hashes": [
@@ -94,11 +94,11 @@
         },
         "jsonschema": {
             "hashes": [
-                "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163",
-                "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"
+                "sha256:2b3cca28580511d44326f0e7fc582eab3cbe31aabd1a1c2cfa74a399796ffd84",
+                "sha256:9dd7c33b4a96138dc37bb86b3610d3b12d30d96433d4d73435ca3025804154a8"
             ],
             "index": "pypi",
-            "version": "==3.2.0"
+            "version": "==4.1.0"
         },
         "psycopg2": {
             "hashes": [
@@ -144,10 +144,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da",
-                "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"
+                "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c",
+                "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"
             ],
-            "version": "==2021.1"
+            "version": "==2021.3"
         },
         "six": {
             "hashes": [
@@ -175,6 +175,14 @@
         }
     },
     "develop": {
+        "flake8": {
+            "hashes": [
+                "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d",
+                "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"
+            ],
+            "index": "pypi",
+            "version": "==4.0.1"
+        },
         "freezegun": {
             "hashes": [
                 "sha256:177f9dd59861d871e27a484c3332f35a6e3f5d14626f2bf91be37891f18927f3",
@@ -182,6 +190,29 @@
             ],
             "index": "pypi",
             "version": "==1.1.0"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
+                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.8.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
+                "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.0"
         },
         "python-dateutil": {
             "hashes": [

--- a/server/camphoric/urls.py
+++ b/server/camphoric/urls.py
@@ -4,6 +4,7 @@ from rest_framework.routers import DefaultRouter
 from camphoric import views
 
 router = DefaultRouter()
+
 router.register('organizations', views.OrganizationViewSet, basename='organization')
 router.register('events', views.EventViewSet, basename='event')
 router.register('registrations', views.RegistrationViewSet, basename='registration')
@@ -13,11 +14,15 @@ router.register('lodgings', views.LodgingViewSet, basename='lodging')
 router.register('campers', views.CamperViewSet, basename='camper')
 router.register('deposits', views.DepositViewSet, basename='deposit')
 router.register('payments', views.PaymentViewSet, basename='payment')
+
 urlpatterns = router.urls + [
+    path('set-csrf-cookie', views.SetCSRFCookieView.as_view()),
+    path('login', views.LoginView.as_view()),
+    path('logout', views.LogoutView.as_view()),
     path(
         'events/<int:event_id>/register', 
         views.RegisterView.as_view(),
         name='register',
     ),
-    path('invitations/<int:invitation_id>/send', views.SendInvitationView.as_view(),),
+    path('invitations/<int:invitation_id>/send', views.SendInvitationView.as_view()),
 ]

--- a/server/camphoric_server/settings.py
+++ b/server/camphoric_server/settings.py
@@ -147,4 +147,6 @@ REST_FRAMEWORK = {
     ]
 }
 
+SESSION_COOKIE_SECURE = True
+
 django_heroku.settings(locals(), databases = not DEBUG)

--- a/server/camphoric_server/settings.py
+++ b/server/camphoric_server/settings.py
@@ -91,6 +91,8 @@ DATABASES = {
     'default': env.db(),
 }
 
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # Password validation

--- a/server/setup.cfg
+++ b/server/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max_line_length = 100


### PR DESCRIPTION
We talked about doing authentication with HttpOnly session cookies as a more secure option than the token-based auth we currently have. We put the idea on hold because we couldn't find any off-the-shelf implementations for Django REST Framework. It turns out not to be not too complicated.

The main complication is dealing with CSRF tokens. The solution here is to do a `GET /api/set-csrf-cookie`, then include the value of the `csrftoken` cookie in the `X-CSRFToken` header in subsequent POST/PUT/PATCH/DELETE requests.