### PR TITLE
Fix frontend client login

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,12 +3,70 @@ import Spinner from 'components/Spinner';
 import StateProvider from 'hooks/Provider';
 import Router from 'navigation/Router';
 
-const App = () => (
-  <StateProvider>
-    <Suspense fallback={<Spinner />}>
-      <Router />
-    </Suspense>
-  </StateProvider>
-);
+import { UserInfo } from 'hooks/admin';
+
+const App = () => {
+  const [csrfStatus, setCsrfStatus] = React.useState<'unfetched' | 'fetching' | 'set'>('unfetched');
+  const [user, setUser] = React.useState<UserInfo | undefined | 'fetching'>(undefined);
+
+  // set the CSRF cookie and user info before we do anything
+  React.useEffect(() => {
+    checkCsrf();
+
+    function checkCsrf() {
+      if (csrfStatus === 'fetching' ) return;
+      if (csrfStatus === 'set') {
+        getUser();
+        return;
+      }
+
+      setCsrfStatus('fetching');
+
+      fetch('/api/set-csrf-cookie').then(r => {
+        if (!r.ok) throw new Error('got a bad response');
+
+        return r.json();
+      }).then((r) => {
+        if (r?.detail !== 'CSRF cookie set') {
+          throw new Error('got a bad response');
+        }
+
+        setCsrfStatus('set');
+      }).catch(() => {
+
+        // start over
+        setCsrfStatus('unfetched');
+      });
+    }
+
+    function getUser() {
+      if (user !== undefined) return;
+
+      setUser('fetching');
+
+      fetch('/api/user').then(r => {
+        if (!r.ok) throw new Error('got a bad response');
+
+        return r.json();
+      }).then(setUser).catch((e) => {
+        // start over
+        setUser(undefined);
+      });
+    }
+  }, [csrfStatus, user]);
+
+  // do not proceed without a CSRF cookie!
+  if (csrfStatus !== 'set') return <Spinner />;
+  // do not proceed without a login status!
+  if (user === undefined || user === 'fetching') return <Spinner />;
+
+  return (
+    <StateProvider initialUser={user}>
+      <Suspense fallback={<Spinner />}>
+        <Router />
+      </Suspense>
+    </StateProvider>
+  );
+};
 
 export default App;

--- a/client/src/hooks/admin.ts
+++ b/client/src/hooks/admin.ts
@@ -4,20 +4,30 @@ import { useLocation } from 'react-router-dom';
 // const memoize = (func: Function) => func;
 
 /**
- * useAuthToken hook
+ * useUser hook
  *
  * This hook is not created via a factory, because it's value type is different
  * than all others.
  */
-export const AuthContext = React.createContext({
-  set: (value: string) => {},
-  value: '',
+export type UserInfo = {
+  email: string,
+  loggedIn: boolean,
+}
+
+export const unauthenticatedUser = {
+  email: 'none',
+  loggedIn: false,
+};
+
+export const UserContext = React.createContext({
+  set: (value: UserInfo) => {},
+  value: unauthenticatedUser as UserInfo,
 });
 
-export function useAuthToken() {
-  const authToken = React.useContext(AuthContext);
+export function useUser() {
+  const user = React.useContext(UserContext);
 
-  return authToken;
+  return user;
 }
 
 type ContextValueStatus = 'undef' | 'fetching' | 'done';

--- a/client/src/navigation/GuardedRoute.tsx
+++ b/client/src/navigation/GuardedRoute.tsx
@@ -1,23 +1,20 @@
 import React from 'react';
-import { Route } from 'react-router-dom';
+import { Route, RouteProps } from 'react-router-dom';
 
 import Login from './Login';
-import { useAuthToken } from 'hooks/admin';
+import { useUser } from 'hooks/admin';
 
-type Props =  {
-  children: React.ReactNode,
-  path: string,
-  exact?: boolean,
-};
+type Props = Omit<RouteProps, 'component'>;
 
 function GuardedRoute({ children, ...rest }: Props) {
-  const authToken = useAuthToken();
+  const userInfo = useUser();
+  const user = userInfo.value;
 
   return (
     <Route {...rest} render={(props) => (
-      authToken.value ? children : (
+      user.loggedIn ? children : (
         <Login
-          onLoginSuccess={authToken.set}
+          onLoginSuccess={userInfo.set}
           onLoginFail={(e) => console.log(e)}
         />
       )

--- a/client/src/navigation/Login/styles.scss
+++ b/client/src/navigation/Login/styles.scss
@@ -1,0 +1,5 @@
+.container.login-form {
+  button {
+    margin-bottom: 1rem;
+  }
+}

--- a/client/src/navigation/RouterConfig.tsx
+++ b/client/src/navigation/RouterConfig.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-router-dom';
 
 import Default from 'components/Default';
+import GuardedRoute from './GuardedRoute';
 
 const RegisterPage = React.lazy(() => import('pages/Register'));
 
@@ -20,7 +21,7 @@ const Lodging = React.lazy(() => import('pages/EventAdmin/Lodging'));
 const Reports = React.lazy(() => import('pages/EventAdmin/Reports'));
 const Settings = React.lazy(() => import('pages/EventAdmin/Settings'));
 
-//                        rel-url label   component
+//                        url     label   component
 export type RouteTuple = [string, string, React.ComponentType];
 export type RouteList = Array<RouteTuple>;
 
@@ -44,15 +45,19 @@ const RouterConfig = () => {
       <Route exact path="/events/:eventId/register" component={RegisterPage} />
       <Redirect exact from="/admin" to="/admin/organization" />
 
-      <Route exact path="/admin/organization" component={OrganizationChooser} />
+      <GuardedRoute exact path="/admin/organization">
+        <OrganizationChooser />
+      </GuardedRoute>
       <Redirect exact
         from="/admin/organization/:organizationId"
         to="/admin/organization/:organizationId/event"
       />
-      <Route exact path="/admin/organization/:organizationId/event" component={EventChooser} />
-      <Route path="/admin/organization/:organizationId/event/:eventId">
+      <GuardedRoute exact path="/admin/organization/:organizationId/event">
+        <EventChooser />
+      </GuardedRoute>
+      <GuardedRoute path="/admin/organization/:organizationId/event/:eventId">
         <EventAdmin routes={eventAdminRoutes} />
-      </Route>
+      </GuardedRoute>
     </Switch>
   );
 };

--- a/server/camphoric/urls.py
+++ b/server/camphoric/urls.py
@@ -18,6 +18,7 @@ router.register('payments', views.PaymentViewSet, basename='payment')
 urlpatterns = router.urls + [
     path('set-csrf-cookie', views.SetCSRFCookieView.as_view()),
     path('login', views.LoginView.as_view()),
+    path('user', views.UserView.as_view()),
     path('logout', views.LogoutView.as_view()),
     path(
         'events/<int:event_id>/register', 

--- a/server/camphoric/views.py
+++ b/server/camphoric/views.py
@@ -71,7 +71,8 @@ class LoginView(APIView):
             password=request.data.get('password'))
         if user is not None:
             login(request, user)
-            return Response({'detail': 'Success'})
+            return Response({'email': user.email, 'loggedIn': True})
+
         return Response({'detail': 'Login failed'}, status=400)
 
 
@@ -79,8 +80,18 @@ class LogoutView(APIView):
     def post(self, request):
         logout(request)
 
-        return Response({'detail': 'Logged out'})
+        return Response({'email': 'none', 'loggedIn': False})
 
+# TODO: create a user serializer so that we can have CRUDy users
+# see https://github.com/camphoric/camphoric/issues/133
+class UserView(APIView):
+    def get(self, request):
+        user = self.request.user
+
+        if user.is_authenticated:
+            return Response({'email': user.email, 'loggedIn': True})
+
+        return Response({'email': 'none', 'loggedIn': False})
 
 class OrganizationViewSet(ModelViewSet):
     queryset = models.Organization.objects.all()

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -29,12 +29,24 @@ class LoginTests(APITestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_good_login(self):
+        response = self.client.get('/api/user')
+        self.assertEqual(response.status_code, 200)
+        self.assertJSONEqual(
+            str(response.content, encoding='utf8'),
+            {'email': 'none', 'loggedIn': False})
+
         response = self.client.post(
             '/api/login',
             {'username': 'tom', 'password': 'password'},
             format='json')
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.cookies['sessionid']['httponly'])
+
+        response = self.client.get('/api/user')
+        self.assertEqual(response.status_code, 200)
+        self.assertJSONEqual(
+            str(response.content, encoding='utf8'),
+            {'email': 'tom@example.com', 'loggedIn': True})
 
         response = self.client.get('/api/organizations/')
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This does the following:

- Adds `/api/user` to check if a user is logged in or not.
- Adds auth state/hooks to check if a user is logged in. Eventually we should make it so that any api call that returns a 401 sets the isLoggedIn value to false.
- Replaces code that references auth token in local storage with the new useAuth hook
- Adds a step in the app startup to make sure a csrf token is set, and also checks if the user is logged in so the app loads correctly.
- Implements the above into the GatedRoute and Login components.

fixes #125

TODO:

#133 