### PR TITLE
Add styling to align input groups

### DIFF
--- a/client/src/pages/EventAdmin/Home.scss
+++ b/client/src/pages/EventAdmin/Home.scss
@@ -1,0 +1,14 @@
+// Boostrap width utilities is limiting and only has a few percentage options.
+// Needed more dynamic custom styling than made sense inline.
+// https://stackoverflow.com/questions/50477193/bootstrap4-make-all-input-group-addons-same-width
+.home-input-group {
+    margin-right: -1px;
+    width: 30%;
+    max-width: 115px;
+    .input-group-text {
+        width: 100%;
+        overflow: hidden;
+        display: inline-flex;
+    }
+}
+

--- a/client/src/pages/EventAdmin/Home.tsx
+++ b/client/src/pages/EventAdmin/Home.tsx
@@ -7,6 +7,8 @@ import Spinner from 'components/Spinner';
 import ShowRawJSON from './ShowRawJSON';
 import createEventEditForm from './createEventEditForm';
 
+import './Home.scss'
+
 function EventAdminHome() {
   const { eventId } = useParams<RouterUrlParams>();
   const { value: event } = useEvent(eventId);
@@ -22,7 +24,7 @@ function EventAdminHome() {
         formItems.map(
           ({ label, field, Input, passProps }) => (
             <InputGroup key={field}>
-              <InputGroup.Prepend>
+              <InputGroup.Prepend className="home-input-group">
                 <InputGroup.Text>{label}</InputGroup.Text>
               </InputGroup.Prepend>
               <Input


### PR DESCRIPTION
Added custom styling so that input groups prepends on the home page have
a uniform width as opposed to boostrap default flex display.