### PR TITLE
Add docker settings for client

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:16-alpine
+ENV PATH /app/node_modules/.bin:$PATH
+WORKDIR /app
+COPY . .
+RUN apk add --no-cache --virtual build-deps python3 py3-pip make g++ \
+    && npm install && npm rebuild node-sass

--- a/client/docker-compose.yml
+++ b/client/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+
+services:
+  react:
+    build: .
+    networks:
+      - default
+    volumes:
+      - .:/app
+      - /app/node_modules
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env.development
+    command: yarn start
+
+
+networks:
+  default:
+    external: true
+    name: server_default

--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "name": "camphoric",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://localhost:8000/",
+  "proxy": "http://web:8000/",
   "dependencies": {
     "@rjsf/bootstrap-4": "^3.1.0",
     "@rjsf/core": "^3.1.0",


### PR DESCRIPTION
* Add minimal docker setup for client side.
* Had limitations regarding some incompatibilities due to the m1 chip.
* Probably need to find a workaround to set the proxy in `package.json` if we're going to allow manual setup as well.

#126 