### PR TITLE
Fix navbar links

### DIFF
--- a/client/src/navigation/EventAdminContainer/NavBar.tsx
+++ b/client/src/navigation/EventAdminContainer/NavBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useRouteMatch } from 'react-router-dom';
 
 import { Navbar, Nav } from 'react-bootstrap';
 
@@ -16,6 +16,7 @@ function ExportedNavBar (props: Props) {
   const organization =
     useOrganizations().value.find(o => o.id === props.event.organization)
     || { name: '' };
+  const { url } = useRouteMatch();
 
   return(
     <Navbar bg="light" expand="lg">
@@ -29,7 +30,7 @@ function ExportedNavBar (props: Props) {
           {
             props.routes.map(
               ([route, title]) => (
-                <Nav.Link key={route} as={Link} to={route}>{title}</Nav.Link>
+                <Nav.Link key={route} as={Link} to={`${url}/${route}`}>{title}</Nav.Link>
               )
             )
           }

--- a/client/src/navigation/EventAdminContainer/index.tsx
+++ b/client/src/navigation/EventAdminContainer/index.tsx
@@ -2,14 +2,15 @@ import React from 'react';
 import {
   Switch,
   Redirect,
+  Route,
   useParams,
   useLocation,
+  useRouteMatch,
 } from 'react-router-dom';
 
 import { Container, Row, Col } from 'react-bootstrap';
 
 import Spinner from 'components/Spinner';
-import GuardedRoute from 'navigation/GuardedRoute';
 import { useEvent } from 'hooks/admin';
 
 import NavBar from './NavBar';
@@ -25,6 +26,7 @@ function EventAdmin({ routes }: Props) {
   const { eventId } = useParams<RouterUrlParams>();
   const { value: event } = useEvent(eventId);
   const { pathname } = useLocation();
+  const { url } = useRouteMatch();
 
   if (!event) return <Spinner />;
 
@@ -37,13 +39,13 @@ function EventAdmin({ routes }: Props) {
         {
           routes.map(
             ([route,, Comp]) => (
-              <GuardedRoute path={route} key={route}>
-                <div className={`event-admin-section-${route}`}><Comp /></div>
-              </GuardedRoute>
+              <Route path={`${url}/${route}`} key={route}>
+                <div className={`event-admin-section-${route}`}><Comp event={event} /></div>
+              </Route>
             )
           )
         }
-        <Redirect to="/admin/organization/:organizationId/event/:eventId/home" />
+        <Redirect to={`${url}/home`} />
       </Switch>
     </Col></Row></Container>
   );

--- a/client/src/navigation/RouterConfig.tsx
+++ b/client/src/navigation/RouterConfig.tsx
@@ -22,16 +22,16 @@ const Reports = React.lazy(() => import('pages/EventAdmin/Reports'));
 const Settings = React.lazy(() => import('pages/EventAdmin/Settings'));
 
 //                        url     label   component
-export type RouteTuple = [string, string, React.ComponentType];
+export type RouteTuple = [string, string, React.ComponentType<{ event: ApiEvent }>];
 export type RouteList = Array<RouteTuple>;
 
 const eventAdminRoutes: RouteList = [
-  ['/admin/organization/:organizationId/event/:eventId/home', 'Home', Home],
-  ['/admin/organization/:organizationId/event/:eventId/registrations', 'Registrations', Registrations],
-  ['/admin/organization/:organizationId/event/:eventId/campers', 'Campers', Registrations],
-  ['/admin/organization/:organizationId/event/:eventId/lodging', 'Lodging', Lodging],
-  ['/admin/organization/:organizationId/event/:eventId/reports', 'Reports', Reports],
-  ['/admin/organization/:organizationId/event/:eventId/settings', 'Settings', Settings],
+  ['home', 'Home', Home],
+  ['registrations', 'Registrations', Registrations],
+  ['campers', 'Campers', Registrations],
+  ['lodging', 'Lodging', Lodging],
+  ['reports', 'Reports', Reports],
+  ['settings', 'Settings', Settings],
 ];
 
 

--- a/client/src/pages/EventAdmin/Home.tsx
+++ b/client/src/pages/EventAdmin/Home.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 import { InputGroup } from 'react-bootstrap';
-import { useParams } from 'react-router-dom';
 
-import { useEvent } from 'hooks/admin';
 import Spinner from 'components/Spinner';
 import ShowRawJSON from './ShowRawJSON';
 import createEventEditForm from './createEventEditForm';
 
 import './Home.scss'
 
-function EventAdminHome() {
-  const { eventId } = useParams<RouterUrlParams>();
-  const { value: event } = useEvent(eventId);
+interface Props {
+  event: ApiEvent,
+}
 
+function EventAdminHome({ event }: Props) {
   if (!event) return <Spinner />;
 
   const formItems = createEventEditForm(event);

--- a/client/src/pages/EventAdmin/Lodging.tsx
+++ b/client/src/pages/EventAdmin/Lodging.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { useEvent } from 'hooks/admin';
-import { useParams } from 'react-router-dom';
 
-function EventAdminLodging() {
-  const { eventId } = useParams<RouterUrlParams>();
-  const { value: event } = useEvent(eventId);
+interface Props {
+  event: ApiEvent,
+}
 
+function EventAdminLodging({ event }: Props) {
   return (
     <React.Fragment>
       <h1>Lodging</h1>

--- a/client/src/pages/EventAdmin/Registrations.tsx
+++ b/client/src/pages/EventAdmin/Registrations.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useRouteMatch, useParams } from 'react-router-dom';
+import { useRouteMatch } from 'react-router-dom';
 import {
   InputGroup,
   FormControl,
@@ -9,17 +9,18 @@ import {
 } from 'react-bootstrap';
 
 import Spinner from 'components/Spinner';
-import { useEvent } from 'hooks/admin';
 
 import RegistrationSearchResult from './RegistrationSearchResult';
 import RegistrationEdit from './RegistrationEdit';
 
 import { useCombinedEventInfo, useQuery } from 'hooks/admin';
 
-function EventAdminRegistrations() {
+interface Props {
+  event: ApiEvent,
+}
+
+function EventAdminRegistrations({ event }: Props) {
   const { url } = useRouteMatch();
-  const { eventId } = useParams<RouterUrlParams>();
-  const { value: event } = useEvent(eventId);
   const registrationId = useQuery('registrationId');
   const registrationMap = useCombinedEventInfo(event?.id || 0);
   const [searchQuery, setSearchQuery] = React.useState('');

--- a/client/src/pages/EventAdmin/Reports.tsx
+++ b/client/src/pages/EventAdmin/Reports.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
-
-import { useEvent } from 'hooks/admin';
 import Spinner from 'components/Spinner';
 
-function EventAdminReports() {
-  const { eventId } = useParams<RouterUrlParams>();
-  const { value: event } = useEvent(eventId);
+interface Props {
+  event: ApiEvent,
+}
 
+function EventAdminReports({ event }: Props) {
   if (!event) return <Spinner />;
 
   return (

--- a/client/src/pages/EventAdmin/Settings.tsx
+++ b/client/src/pages/EventAdmin/Settings.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
-
-import { useEvent } from 'hooks/admin';
 import Spinner from 'components/Spinner';
 
-function EventAdminSettings() {
-  const { eventId } = useParams<RouterUrlParams>();
-  const { value: event } = useEvent(eventId);
+interface Props {
+  event: ApiEvent,
+}
 
+function EventAdminSettings({ event }: Props) {
   if (!event) return <Spinner />;
 
   return (


### PR DESCRIPTION
Since the url params aren't available in subroutes (until react-router-dom v6, where routing and subrouting is rewritten), we have to pass the event in as a prop.