### PR TITLE
Create user views, user serializer,  and CRUD tests for user endpoints

### DIFF
--- a/server/camphoric/serializers.py
+++ b/server/camphoric/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework.serializers import ModelSerializer, ValidationError
+from django.contrib.auth.models import User
 import jsonschema  # Using Draft-7
 
 import camphoric.models
@@ -77,6 +78,17 @@ class PaymentSerializer(ModelSerializer):
 
     def validate(self, data):
         return validate_attributes(data, data['registration'].event.payment_schema)
+
+
+class UserSerializer(ModelSerializer):
+    class Meta:
+        model = User
+        exclude = ['password']
+
+    def create(self, validated_data):
+        kwargs = dict(validated_data)
+        del kwargs['username']
+        return User.objects.create_user(validated_data['username'], **kwargs)
 
 
 def validate_schema(schema):

--- a/server/camphoric/urls.py
+++ b/server/camphoric/urls.py
@@ -14,6 +14,8 @@ router.register('lodgings', views.LodgingViewSet, basename='lodging')
 router.register('campers', views.CamperViewSet, basename='camper')
 router.register('deposits', views.DepositViewSet, basename='deposit')
 router.register('payments', views.PaymentViewSet, basename='payment')
+router.register('users', views.UserViewSet, basename='user')
+
 
 urlpatterns = router.urls + [
     path('set-csrf-cookie', views.SetCSRFCookieView.as_view()),

--- a/server/camphoric/views.py
+++ b/server/camphoric/views.py
@@ -4,6 +4,7 @@ from smtplib import SMTPException
 
 import chevron
 from django.contrib.auth import authenticate, login, logout
+from django.contrib.auth.models import User
 from django.core import mail
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
@@ -144,6 +145,12 @@ class DepositViewSet(ModelViewSet):
 class PaymentViewSet(ModelViewSet):
     queryset = models.Payment.objects.all()
     serializer_class = serializers.PaymentSerializer
+    permission_classes = [permissions.IsAdminUser]
+
+
+class UserViewSet(ModelViewSet):
+    queryset = User.objects.all().order_by('-date_joined')
+    serializer_class = serializers.UserSerializer
     permission_classes = [permissions.IsAdminUser]
 
 

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -555,6 +555,7 @@ class SendInvitationPostTests(APITestCase):
         invitation.refresh_from_db()
         self.assertIsNotNone(invitation.sent_time)
         
+
 class UsersTests(APITestCase):
     def setUp(self):
         self.admin_user = User.objects.create_superuser("tom", "tom@example.com", "password")
@@ -574,7 +575,6 @@ class UsersTests(APITestCase):
         self.assertNotIn('password', response.data[0])
 
     def test_create(self):
-        # TODO finish test
 
         response = self.client.post(
             '/api/users/',
@@ -582,11 +582,34 @@ class UsersTests(APITestCase):
             format='json'
         )
 
+        self.assertEqual(response.status_code, 201)
         user = User.objects.get(username='jerry')
         self.assertFalse(user.has_usable_password())
+        self.assertEqual(user.get_username(), 'jerry')
+        self.assertIsInstance(user, User)
+        self.assertEqual(len(User.objects.all()), 2)
 
-    # TODO: make tests for get/edit/delete user endpoints
+    def test_edit(self):
 
-            
-       
+        user = User.objects.create_user(username='jerry')
+        self.assertEqual(user.email, '')
 
+        response = self.client.put(
+            f'/api/users/{user.id}/',
+            {'username': 'jerry', 'email': 'jerry@example.com'},
+            format='json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        updated_user = User.objects.get(username='jerry')
+        self.assertEqual(updated_user.email, 'jerry@example.com')
+
+    def test_delete(self):
+
+        user = User.objects.create_user(username='jerry')
+
+        response = self.client.delete(f'/api/users/{user.id}/')
+        self.assertEqual(response.status_code, 204)
+
+        with self.assertRaises(User.DoesNotExist):
+            User.objects.get(id=user.id)

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -555,3 +555,38 @@ class SendInvitationPostTests(APITestCase):
         invitation.refresh_from_db()
         self.assertIsNotNone(invitation.sent_time)
         
+class UsersTests(APITestCase):
+    def setUp(self):
+        self.admin_user = User.objects.create_superuser("tom", "tom@example.com", "password")
+        self.client.login(username='tom', password='password')
+
+    def test_list_unauthorized(self):
+        self.client.logout()
+        response = self.client.get('/api/users/')
+        self.assertEqual(response.status_code, 401)
+
+    def test_list_authorized(self):
+        response = self.client.get('/api/users/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(response.data, list)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['username'], 'tom')
+        self.assertNotIn('password', response.data[0])
+
+    def test_create(self):
+        # TODO finish test
+
+        response = self.client.post(
+            '/api/users/',
+            {'username': 'jerry'},
+            format='json'
+        )
+
+        user = User.objects.get(username='jerry')
+        self.assertFalse(user.has_usable_password())
+
+    # TODO: make tests for get/edit/delete user endpoints
+
+            
+       
+


### PR DESCRIPTION
Created user serializer, along with user view set and urls.

Returns user(s) without passwords. Currently, users created without a password are set an unusable password. We want to be able to then send that user a link to set their password. Admins are able to edit details of other admins except for password.

NEXT STEPS
create separate flow to handle passwords (endpoint for user to set password via email, endpoint for user to change password given current password)
LoginView and UserView to return serialized user object (call user serializer on user object) or return a 401 if no one is logged in

QUESTIONS
How does LogoutView need to change?