### PR TITLE
Fix little docker problems

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -3,4 +3,4 @@ ENV PATH="/app/node_modules/.bin:${PATH}"
 WORKDIR /app
 COPY . .
 RUN apk add --no-cache --virtual build-deps python3 py3-pip make g++
-RUN yarn
+RUN yarn install --frozen-lockfile

--- a/doc/development.md
+++ b/doc/development.md
@@ -271,16 +271,23 @@ docker-compose logs -f django
 
 ### Container/image/volume removal
 
-There is a script that will do this for you:
+**Delete all containers**
+
+If you want to PERMENANTLY delete images, volumes, and containers associated
+with camphoric:
 
 ```
 ./remove-all-docker-artifacts
 ```
 
-This script will:
+use `./remove-all-docker-artifacts -h` for more details
 
-- delete any containers created with docker-compose
-- delete any images not associated with containers
-- delete any volumes not associated with containers
+**Delete unused artifacts**
 
-If you want to be targeted about it, we recommend using the docker desktop GUI.
+If you just want to clean up some hard drive space:
+
+```
+./remove-unused-docker-artifacts
+```
+
+use `./remove-unused-docker-artifacts -h` for more details

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,6 @@ services:
     volumes:
       - ./client:/app
       - ./data:/app/fixtures
-      - ./client/package.json:/app/package.json
       - /app/node_modules
     ports:
       - "3000:3000"

--- a/remove-unused-docker-artifacts
+++ b/remove-unused-docker-artifacts
@@ -2,10 +2,9 @@
 
 function usage() {
     cat <<EOF
-Usage: $0 [-yf] [image-name]
+Usage: $0 [-yf]
 
-This will PERMENANTLY delete images, volumes, and containers associated with
-${PWD##*/}.  If you omit the optional image name, it will delete all of them.
+This will PERMENANTLY delete ALL unused images and volumes.
 EOF
 
 }
@@ -20,18 +19,14 @@ do
     esac
 done
 
-shift $((OPTIND-1)) # remove all flag arguments
-
 if [ -z "$force" ]
 then
     RED='\033[1;31m'
     NC='\033[0m' # No Color
-
-    echo "$*"
-
+    
     printf "${RED}WARNING: THIS CANNOT BE UNDONE${NC}\n"
-    echo "This will delete all images, volumes, and containers associate with ${PWD##*/}"
-
+    echo "This will delete all unused images and volumes"
+    
     while true; do
         read -p "Do you wish to proceed [y/n]? " yn
         case $yn in
@@ -42,5 +37,5 @@ then
     done
 fi
 
-docker-compose rm -sf $*
-./remove-unused-docker-artifacts -f
+docker image prune -af
+docker volume prune -f


### PR DESCRIPTION
## Split cleanup scripts

While working on the rebuilding of the react container, I found it handy to delete just the react container, and cleanup after than, and then just rebuild react.  The splitting of these scripts made that possible

## Prevent yarn.lock changing during container init

The way that Dockerfile and docker-compose.yml work together means that when the container is built the yarn.lock could change if you just use `yarn [install]`. The --frozen-lockfile prevents any updates when the container is first built. 

After the build, docker-compose will run the container, mounting its volumes, overwriting any changes made to the container during the build phase.

There is also one unused volume that wasn't doing anything.

## Post merge actions

```
./remove-all-docker-artifacts react
docker-compose up -d --no-deps --build react
```