### PR TITLE
Generate lodging schema for registration form

### DIFF
--- a/data/lark/lodgings.mjs
+++ b/data/lark/lodgings.mjs
@@ -1,0 +1,63 @@
+    //event = models.ForeignKey(Event, on_delete=models.CASCADE)
+    //parent = models.ForeignKey('self', on_delete=models.CASCADE, null=True)
+    //name = models.CharField(max_length=255)
+    //children_title = models.CharField(
+        //max_length=255, blank=True, default='',
+        //help_text="title that goes on the dropdown field to select a child")
+    //# For non-leaf nodes, "capacity" and "reserved" should be set to zero. 
+    //capacity = models.IntegerField(default=0, help_text="total camper capacity") 
+    //reserved = models.IntegerField(default=0, help_text="number of reserved spots remaining")
+    //visible = models.BooleanField(default=False, help_text="true if visible on registration form")
+    //notes = models.TextField(blank=True, default='')
+
+export default {
+    root: {
+        name: "Lodging",
+        children_title: "Select a camp",
+        visible: true,
+    },
+    camp1: {
+        parentKey: "root",
+        name: "Camp 1",
+        children_title: "Select a lodging type",
+        visible: true,
+    },
+    camp2: {
+        parentKey: "root",
+        name: "Camp 2",
+        children_title: "Select a lodging type",
+        visible: true,
+    },
+
+    camp1_tent: {
+        parentKey: "camp1",
+        name: "Camp 1: Tent",
+        visible: true,
+    },
+    camp1_rv: {
+        parentKey: "camp1",
+        name: "Camp 1: RV",
+        visible: true,
+    },
+    camp1_cabin: {
+        parentKey: "camp1",
+        name: "Camp 1: Cabin",
+        visible: true,
+    },
+
+    camp2_tent: {
+        parentKey: "camp2",
+        name: "Camp 2: Tent",
+        visible: true,
+    },
+    camp2_rv: {
+        parentKey: "camp2",
+        name: "Camp 2: RV",
+        visible: true,
+    },
+    camp2_cabin: {
+        parentKey: "camp2",
+        name: "Camp 2: Cabin",
+        visible: true,
+    },
+};

--- a/data/lark/registrationUISchema.mjs
+++ b/data/lark/registrationUISchema.mjs
@@ -56,6 +56,7 @@ export default {
           "session",
           "accommodations",
           "meals",
+          "lodging",
         ],
         "camper_address": address,
       }

--- a/server/camphoric/lodging.py
+++ b/server/camphoric/lodging.py
@@ -1,10 +1,9 @@
 from collections import defaultdict
 
-from django.db.models import prefetch_related_objects
 
 def get_lodging_schema(event, show_all=False):
     tree = LodgingTree(event, show_all).build()
-    
+
     def make_enum(node):
         children = node.visible_children
 
@@ -61,7 +60,7 @@ def get_lodging_schema(event, show_all=False):
             'properties': {},
             'dependencies': {},
         }
-        
+
     return {
         'type': 'object',
         'title': root.lodging.name,

--- a/server/camphoric/lodging.py
+++ b/server/camphoric/lodging.py
@@ -49,6 +49,9 @@ def get_lodging_schema(event, show_all=False):
         }
 
     root = tree.root
+    if root is None:
+        return None
+
     children = root.visible_children
 
     if len(children) == 0:
@@ -74,6 +77,7 @@ class LodgingTree:
     def __init__(self, event, show_all):
         self.event = event
         self.show_all = show_all
+        self.root = None
 
     def build(self):
         root_lodging = None
@@ -87,10 +91,8 @@ class LodgingTree:
             else:
                 root_lodging = lodging
 
-        if not root_lodging:
-            raise RuntimeError('Event has no root Lodgings')
-
-        self.root = self._build_subtree(root_lodging, children_lookup)
+        if root_lodging:
+            self.root = self._build_subtree(root_lodging, children_lookup)
 
         return self
 

--- a/server/camphoric/lodging.py
+++ b/server/camphoric/lodging.py
@@ -1,26 +1,66 @@
 def get_lodging_schema(event):
     root = event.lodging_set.get(parent=None)
     
-    children = root.lodging_set.all()
-    is_leaf = len(children) == 0
-    if is_leaf:
+    def make_enum(lodging):
+        children = list(lodging.lodging_set.all())
+
+        if len(children) == 0:
+            return {}
+
         return {
-            "title": root.name,
-            "type": "object",
-            "properties": {}
-        }
-    else:
-        enum = [child.id for child in children]
-        enum_names = [child.name for child in children]
-        return {
-            "title": root.name,
-            "type": "object",
-            "properties": {
-                "lodging_1": {
-                    "title": root.children_title,
-                    "enum": enum,
-                    "enumNames": enum_names
-                }
-            }
+            'title': lodging.children_title,
+            'enum': [child.id for child in children],
+            'enumNames': [child.name for child in children],
         }
 
+    def make_dependencies(lodging, depth):
+        children = list(lodging.lodging_set.all())
+
+        if len(children) == 0:
+            return {}
+
+        dependency_list = [
+            {
+                'properties': {
+                    f'lodging_{depth}': {
+                        'enum': [child.id],
+                    },
+                    f'lodging_{depth + 1}': make_enum(child),
+                },
+                'required': [
+                    f'lodging_{depth + 1}'
+                ],
+                'dependencies': make_dependencies(child, depth + 1),
+            }
+            for child in children if len(child.lodging_set.all()) > 0
+        ]
+
+        if len(dependency_list) == 0:
+            return {}
+
+        return {
+            f'lodging_{depth}': {
+                'oneOf': dependency_list,
+            },
+        }
+
+    root = event.lodging_set.get(parent=None)
+    children = list(root.lodging_set.all())
+
+    if len(children) == 0:
+        return {
+            'type': 'object',
+            'title': root.name,
+            'properties': {},
+            'dependencies': {},
+        }
+        
+    return {
+        'type': 'object',
+        'title': root.name,
+        'properties': {
+            'lodging_1': make_enum(root),
+        },
+        'required': ['lodging_1'],
+        'dependencies': make_dependencies(root, 1),
+    }

--- a/server/camphoric/lodging.py
+++ b/server/camphoric/lodging.py
@@ -1,20 +1,24 @@
+from collections import defaultdict
+
+from django.db.models import prefetch_related_objects
+
 def get_lodging_schema(event):
-    root = event.lodging_set.get(parent=None)
+    tree = LodgingTree(event).build()
     
-    def make_enum(lodging):
-        children = list(lodging.lodging_set.all())
+    def make_enum(node):
+        children = node.visible_children
 
         if len(children) == 0:
             return {}
 
         return {
-            'title': lodging.children_title,
-            'enum': [child.id for child in children],
-            'enumNames': [child.name for child in children],
+            'title': node.lodging.children_title,
+            'enum': [child.lodging.id for child in children],
+            'enumNames': [child.lodging.name for child in children],
         }
 
-    def make_dependencies(lodging, depth):
-        children = list(lodging.lodging_set.all())
+    def make_dependencies(node, depth):
+        children = node.visible_children
 
         if len(children) == 0:
             return {}
@@ -23,7 +27,7 @@ def get_lodging_schema(event):
             {
                 'properties': {
                     f'lodging_{depth}': {
-                        'enum': [child.id],
+                        'enum': [child.lodging.id],
                     },
                     f'lodging_{depth + 1}': make_enum(child),
                 },
@@ -32,7 +36,7 @@ def get_lodging_schema(event):
                 ],
                 'dependencies': make_dependencies(child, depth + 1),
             }
-            for child in children if len(child.lodging_set.all()) > 0
+            for child in children if len(child.visible_children) > 0
         ]
 
         if len(dependency_list) == 0:
@@ -44,23 +48,67 @@ def get_lodging_schema(event):
             },
         }
 
-    root = event.lodging_set.get(parent=None)
-    children = list(root.lodging_set.all())
+    root = tree.root
+    children = root.visible_children
 
     if len(children) == 0:
         return {
             'type': 'object',
-            'title': root.name,
+            'title': root.lodging.name,
             'properties': {},
             'dependencies': {},
         }
         
     return {
         'type': 'object',
-        'title': root.name,
+        'title': root.lodging.name,
         'properties': {
             'lodging_1': make_enum(root),
         },
         'required': ['lodging_1'],
         'dependencies': make_dependencies(root, 1),
     }
+
+
+class LodgingTree:
+    def __init__(self, event):
+        self.event = event
+
+    def build(self):
+        root_lodging = None
+        children_lookup = defaultdict(list)
+
+        for lodging in self.event.lodging_set.all():
+            if lodging.parent_id:
+                children_lookup[lodging.parent_id].append(lodging)
+            elif root_lodging:
+                raise RuntimeError('Event has multiple root')
+            else:
+                root_lodging = lodging
+
+        if not root_lodging:
+            raise RuntimeError('Event has no root Lodgings')
+
+        self.root = self._build_subtree(root_lodging, children_lookup)
+
+        return self
+
+    def _build_subtree(self, lodging, children_lookup):
+        return LodgingTreeNode(
+            lodging,
+            [
+                self._build_subtree(child_lodging, children_lookup)
+                for child_lodging in children_lookup[lodging.id]
+            ]
+        )
+
+
+class LodgingTreeNode:
+    def __init__(self, lodging, children):
+        self.lodging = lodging
+        self.children = children
+
+    @property
+    def visible_children(self):
+        # TODO: filter out nodes with no remaining capacity or which are not visible
+        return self.children

--- a/server/camphoric/lodging.py
+++ b/server/camphoric/lodging.py
@@ -1,0 +1,26 @@
+def get_lodging_schema(event):
+    root = event.lodging_set.get(parent=None)
+    
+    children = root.lodging_set.all()
+    is_leaf = len(children) == 0
+    if is_leaf:
+        return {
+            "title": root.name,
+            "type": "object",
+            "properties": {}
+        }
+    else:
+        enum = [child.id for child in children]
+        enum_names = [child.name for child in children]
+        return {
+            "title": root.name,
+            "type": "object",
+            "properties": {
+                "lodging_1": {
+                    "title": root.children_title,
+                    "enum": enum,
+                    "enumNames": enum_names
+                }
+            }
+        }
+

--- a/server/camphoric/views.py
+++ b/server/camphoric/views.py
@@ -385,7 +385,7 @@ class RegisterView(APIView):
 
         lodging_id = None
         if 'lodging' in camper_data:
-            camper_data = dict(camper_data) # shallow copy
+            camper_data = dict(camper_data)  # shallow copy
             lodging_data = camper_data['lodging']
             del camper_data['lodging']
             lodging_key = max(

--- a/server/camphoric/views.py
+++ b/server/camphoric/views.py
@@ -25,6 +25,7 @@ from camphoric import (
     pricing,
     serializers,
 )
+from camphoric.lodging import get_lodging_schema
 
 
 logger = logging.getLogger(__name__)
@@ -294,11 +295,20 @@ class RegisterView(APIView):
     def get_form_schema(cls, event):
         if not event.registration_schema:
             return None
+
+        lodging_schema = get_lodging_schema(event)
+
         return {
             **event.registration_schema,
             'definitions': {
                 **event.registration_schema.get('definitions', {}),
-                'camper': event.camper_schema,
+                'camper': {
+                    **event.camper_schema,
+                    'properties': {
+                        **event.camper_schema['properties'],
+                        'lodging': lodging_schema,
+                    },
+                } if lodging_schema else event.camper_schema,
             },
             'required': [
                 *event.registration_schema.get('required', []),

--- a/server/camphoric/views.py
+++ b/server/camphoric/views.py
@@ -351,11 +351,54 @@ class RegisterView(APIView):
             registrant_email=form_data['registrant_email'],
             attributes=registration_attributes,
         )
+
         campers = [
-            models.Camper(registration=registration, attributes=camper_attributes)
-            for camper_attributes in form_data['campers']
+            cls.deserialize_camper(registration, camper_data)
+            for camper_data in form_data['campers']
         ]
+
         return registration, campers
+
+    @classmethod
+    def deserialize_camper(cls, registration, camper_data):
+        '''
+        Transform a dict from the `campers` list in the form data into a Camper
+        model instance. The trickiest thing this does is to determine the
+        lodging_id. `camper_data` looks something like this:
+
+            {
+                # camper attributes corresponding to event.camper_schema, e.g.
+                'name': 'John',
+                'age': 12,
+
+                # lodging selection, not part of event.camper_schema
+                'lodging': {
+                    'lodging_1': 17,
+                    'lodging_2': 20,
+                    'lodging_3': 25
+                }
+            }
+
+        Each item in the `lodging` dict is a selection along the lodging tree.
+        The one with the highest number is the final selection.
+        '''
+
+        lodging_id = None
+        if 'lodging' in camper_data:
+            camper_data = dict(camper_data) # shallow copy
+            lodging_data = camper_data['lodging']
+            del camper_data['lodging']
+            lodging_key = max(
+                lodging_data.keys(),
+                key=lambda k: int(k.split('_')[1])
+            )
+            lodging_id = lodging_data[lodging_key]
+
+        return models.Camper(
+            registration=registration,
+            attributes=camper_data,
+            lodging_id=lodging_id,
+        )
 
     @classmethod
     def find_invitation(cls, request):

--- a/server/tests/test_get_lodging_schema.py
+++ b/server/tests/test_get_lodging_schema.py
@@ -125,10 +125,13 @@ class TestGetLodgingSchema(TestCase):
             notes=''
         )
 
+        # camp1 grandchildren (visible)
+
         tents_camp1 = self.event.lodging_set.create(
             name='Tents in Camp 1',
             parent=camp1,
             capacity=30,
+            visible=True,
             notes=''
         )
 
@@ -136,13 +139,41 @@ class TestGetLodgingSchema(TestCase):
             name='Cabins in Camp 1',
             parent=camp1,
             capacity=30,
+            visible=True,
             notes=''
         )
 
-        rv_camp1 = self.event.lodging_set.create(
+        rvs_camp1 = self.event.lodging_set.create(
             name='RVs in Camp 1',
             parent=camp1,
             capacity=30,
+            visible=True,
+            notes=''
+        )
+
+        # camp2 grandchildren (invisible)
+
+        tents_camp2 = self.event.lodging_set.create(
+            name='Tents in Camp 2',
+            parent=camp2,
+            capacity=30,
+            visible=False,
+            notes=''
+        )
+
+        cabins_camp2 = self.event.lodging_set.create(
+            name='Cabins in Camp 2',
+            parent=camp2,
+            capacity=30,
+            visible=False,
+            notes=''
+        )
+
+        rvs_camp2 = self.event.lodging_set.create(
+            name='RVs in Camp 2',
+            parent=camp2,
+            capacity=30,
+            visible=False,
             notes=''
         )
 
@@ -184,7 +215,7 @@ class TestGetLodgingSchema(TestCase):
                                     'enum': [
                                         tents_camp1.id,
                                         cabins_camp1.id,
-                                        rv_camp1.id,
+                                        rvs_camp1.id,
                                     ],
                                     'enumNames': [
                                         'Tents in Camp 1',

--- a/server/tests/test_get_lodging_schema.py
+++ b/server/tests/test_get_lodging_schema.py
@@ -1,5 +1,8 @@
-from django.test import TestCase
 import json
+
+from django.conf import settings
+from django.db import connection, reset_queries
+from django.test import TestCase
 
 from camphoric import models
 from camphoric.lodging import get_lodging_schema
@@ -23,7 +26,7 @@ class TestGetLodgingSchema(TestCase):
         )
     
     def test_no_lodging(self):
-        with self.assertRaises(models.Lodging.DoesNotExist):
+        with self.assertRaises(RuntimeError):
             get_lodging_schema(self.event)
     
 
@@ -143,7 +146,11 @@ class TestGetLodgingSchema(TestCase):
             notes=''
         )
 
+        # make sure the lodging schema is built with one DB query
+        settings.DEBUG=True
+        reset_queries()
         schema = get_lodging_schema(self.event)
+        self.assertEqual(len(connection.queries), 1)
 
         self.assertEqual(schema, {
             'title': 'Test Lodging',

--- a/server/tests/test_get_lodging_schema.py
+++ b/server/tests/test_get_lodging_schema.py
@@ -1,6 +1,9 @@
 from django.test import TestCase
+import json
+
 from camphoric import models
 from camphoric.lodging import get_lodging_schema
+
 
 class TestGetLodgingSchema(TestCase):
     def setUp(self):
@@ -13,10 +16,10 @@ class TestGetLodgingSchema(TestCase):
             pricing={},
             registration_pricing_logic={},
             camper_pricing_logic={},
-            confirmation_page_template="",
-            confirmation_email_subject="",
-            confirmation_email_template="",
-            confirmation_email_from="foo@example.com"
+            confirmation_page_template='',
+            confirmation_email_subject='',
+            confirmation_email_template='',
+            confirmation_email_from='foo@example.com'
         )
     
     def test_no_lodging(self):
@@ -26,156 +29,165 @@ class TestGetLodgingSchema(TestCase):
 
     def test_lodging_with_single_node(self):
         self.event.lodging_set.create(
-            name="Test Lodging",
-            children_title="",
+            name='Test Lodging',
+            children_title='',
             capacity=30,
             visible=True,
-            notes=""
+            notes=''
         )
         schema = get_lodging_schema(self.event)
         self.assertEqual(schema, {
-            "title": "Test Lodging",
-            "type": "object",
-            "properties": {}
+            'title': 'Test Lodging',
+            'type': 'object',
+            'properties': {},
+            'dependencies': {},
         })
 
     def test_lodging_with_node_with_children(self):
         root = self.event.lodging_set.create(
-            name="Test Lodging",
-            children_title="Please select a Camp",
+            name='Test Lodging',
+            children_title='Please select a Camp',
             visible=True,
-            notes=""
+            notes=''
         )
 
         camp1 = self.event.lodging_set.create(
-            name="Camp 1",
+            name='Camp 1',
             parent=root,
             capacity=30,
             visible=True,
-            notes=""
+            notes=''
         )
 
         camp2 = self.event.lodging_set.create(
-            name="Camp 2",
+            name='Camp 2',
             parent=root,
             capacity=30,
             visible=True,
-            notes=""
+            notes=''
         )
 
         camp3 = self.event.lodging_set.create(
-            name="Camp 3",
+            name='Camp 3',
             parent=root,
             capacity=30,
             visible=True,
-            notes=""
+            notes=''
         )
 
         schema = get_lodging_schema(self.event)
+
         self.assertEqual(schema, {
-            "title": "Test Lodging",
-            "type": "object",
-            "properties": {
-                "lodging_1": {
-                    "title": "Please select a Camp",
-                    "enum": [
+            'title': 'Test Lodging',
+            'type': 'object',
+            'properties': {
+                'lodging_1': {
+                    'title': 'Please select a Camp',
+                    'enum': [
                         camp1.id,
                         camp2.id,
                         camp3.id
                     ],
-                    "enumNames": [
+                    'enumNames': [
                         camp1.name,
                         camp2.name,
                         camp3.name
                     ],
                 },
             },
+            'required': ['lodging_1'],
+            'dependencies': {},
         })
     
     def test_lodging_with_node_with_children_and_grandchildren(self):
         root = self.event.lodging_set.create(
-            name="Test Lodging",
-            children_title="Please select a Camp",
+            name='Test Lodging',
+            children_title='Please select a Camp',
             visible=True,
-            notes=""
+            notes=''
         )
 
         camp1 = self.event.lodging_set.create(
-            name="Camp 1",
-            children_title="Please select a Lodging Type",
+            name='Camp 1',
+            children_title='Please select a Lodging Type',
             parent=root,
             visible=True,
-            notes=""
+            notes=''
         )
 
         camp2 = self.event.lodging_set.create(
-            name="Camp 2",
+            name='Camp 2',
             parent=root,
             visible=True,
-            notes=""
+            notes=''
         )
 
         tents_camp1 = self.event.lodging_set.create(
-            name="Tents in Camp 1",
+            name='Tents in Camp 1',
             parent=camp1,
             capacity=30,
-            notes=""
+            notes=''
         )
 
         cabins_camp1 = self.event.lodging_set.create(
-            name="Cabins in Camp 1",
+            name='Cabins in Camp 1',
             parent=camp1,
             capacity=30,
-            notes=""
+            notes=''
         )
 
         rv_camp1 = self.event.lodging_set.create(
-            name="RVs in Camp 1",
+            name='RVs in Camp 1',
             parent=camp1,
             capacity=30,
-            notes=""
+            notes=''
         )
 
         schema = get_lodging_schema(self.event)
+
         self.assertEqual(schema, {
-            "title": "Test Lodging",
-            "type": "object",
-            "properties": {
-                "lodging_1": {
-                    "title": "Please select a Camp",
-                    "enum": [
+            'title': 'Test Lodging',
+            'type': 'object',
+            'properties': {
+                'lodging_1': {
+                    'title': 'Please select a Camp',
+                    'enum': [
                         camp1.id,
                         camp2.id
                     ],
-                    "enumNames": [
-                        camp1.name,
-                        camp2.name
+                    'enumNames': [
+                        'Camp 1',
+                        'Camp 2',
                     ],
                 },
             },
-            "dependencies": {
-                "lodging_1": {
-                    "oneOf": [
+            'required': ['lodging_1'],
+            'dependencies': {
+                'lodging_1': {
+                    'oneOf': [
                         {
-                            "properties": {
-                                "lodging_1": {
-                                    "enum": [
+                            'properties': {
+                                'lodging_1': {
+                                    'enum': [
                                         camp1.id
                                     ],
                                 },
-                                "lodging_2": {
-                                    "enum": [
+                                'lodging_2': {
+                                    'title': 'Please select a Lodging Type',
+                                    'enum': [
                                         tents_camp1.id,
                                         cabins_camp1.id,
-                                        rv_camp1.id
+                                        rv_camp1.id,
                                     ],
-                                    "enumNames": [
-                                        tents_camp1.name,
-                                        cabins_camp1.name,
-                                        rv_camp1.name
+                                    'enumNames': [
+                                        'Tents in Camp 1',
+                                        'Cabins in Camp 1',
+                                        'RVs in Camp 1',
                                     ]
                                 }
-                            }
+                            },
+                            'required': ['lodging_2'],
+                            'dependencies': {},
                         }
                     ]
                 }

--- a/server/tests/test_get_lodging_schema.py
+++ b/server/tests/test_get_lodging_schema.py
@@ -1,0 +1,183 @@
+from django.test import TestCase
+from camphoric import models
+from camphoric.lodging import get_lodging_schema
+
+class TestGetLodgingSchema(TestCase):
+    def setUp(self):
+        self.organization = models.Organization.objects.create(name='Test Organization')
+        self.event = models.Event.objects.create(
+            organization=self.organization,
+            name='Test Event',
+            registration_schema={},
+            camper_schema={},
+            pricing={},
+            registration_pricing_logic={},
+            camper_pricing_logic={},
+            confirmation_page_template="",
+            confirmation_email_subject="",
+            confirmation_email_template="",
+            confirmation_email_from="foo@example.com"
+        )
+    
+    def test_no_lodging(self):
+        with self.assertRaises(models.Lodging.DoesNotExist):
+            get_lodging_schema(self.event)
+    
+
+    def test_lodging_with_single_node(self):
+        self.event.lodging_set.create(
+            name="Test Lodging",
+            children_title="",
+            capacity=30,
+            visible=True,
+            notes=""
+        )
+        schema = get_lodging_schema(self.event)
+        self.assertEqual(schema, {
+            "title": "Test Lodging",
+            "type": "object",
+            "properties": {}
+        })
+
+    def test_lodging_with_node_with_children(self):
+        root = self.event.lodging_set.create(
+            name="Test Lodging",
+            children_title="Please select a Camp",
+            visible=True,
+            notes=""
+        )
+
+        camp1 = self.event.lodging_set.create(
+            name="Camp 1",
+            parent=root,
+            capacity=30,
+            visible=True,
+            notes=""
+        )
+
+        camp2 = self.event.lodging_set.create(
+            name="Camp 2",
+            parent=root,
+            capacity=30,
+            visible=True,
+            notes=""
+        )
+
+        camp3 = self.event.lodging_set.create(
+            name="Camp 3",
+            parent=root,
+            capacity=30,
+            visible=True,
+            notes=""
+        )
+
+        schema = get_lodging_schema(self.event)
+        self.assertEqual(schema, {
+            "title": "Test Lodging",
+            "type": "object",
+            "properties": {
+                "lodging_1": {
+                    "title": "Please select a Camp",
+                    "enum": [
+                        camp1.id,
+                        camp2.id,
+                        camp3.id
+                    ],
+                    "enumNames": [
+                        camp1.name,
+                        camp2.name,
+                        camp3.name
+                    ],
+                },
+            },
+        })
+    
+    def test_lodging_with_node_with_children_and_grandchildren(self):
+        root = self.event.lodging_set.create(
+            name="Test Lodging",
+            children_title="Please select a Camp",
+            visible=True,
+            notes=""
+        )
+
+        camp1 = self.event.lodging_set.create(
+            name="Camp 1",
+            children_title="Please select a Lodging Type",
+            parent=root,
+            visible=True,
+            notes=""
+        )
+
+        camp2 = self.event.lodging_set.create(
+            name="Camp 2",
+            parent=root,
+            visible=True,
+            notes=""
+        )
+
+        tents_camp1 = self.event.lodging_set.create(
+            name="Tents in Camp 1",
+            parent=camp1,
+            capacity=30,
+            notes=""
+        )
+
+        cabins_camp1 = self.event.lodging_set.create(
+            name="Cabins in Camp 1",
+            parent=camp1,
+            capacity=30,
+            notes=""
+        )
+
+        rv_camp1 = self.event.lodging_set.create(
+            name="RVs in Camp 1",
+            parent=camp1,
+            capacity=30,
+            notes=""
+        )
+
+        schema = get_lodging_schema(self.event)
+        self.assertEqual(schema, {
+            "title": "Test Lodging",
+            "type": "object",
+            "properties": {
+                "lodging_1": {
+                    "title": "Please select a Camp",
+                    "enum": [
+                        camp1.id,
+                        camp2.id
+                    ],
+                    "enumNames": [
+                        camp1.name,
+                        camp2.name
+                    ],
+                },
+            },
+            "dependencies": {
+                "lodging_1": {
+                    "oneOf": [
+                        {
+                            "properties": {
+                                "lodging_1": {
+                                    "enum": [
+                                        camp1.id
+                                    ],
+                                },
+                                "lodging_2": {
+                                    "enum": [
+                                        tents_camp1.id,
+                                        cabins_camp1.id,
+                                        rv_camp1.id
+                                    ],
+                                    "enumNames": [
+                                        tents_camp1.name,
+                                        cabins_camp1.name,
+                                        rv_camp1.name
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        })

--- a/server/tests/test_get_lodging_schema.py
+++ b/server/tests/test_get_lodging_schema.py
@@ -26,9 +26,8 @@ class TestGetLodgingSchema(TestCase):
         )
     
     def test_no_lodging(self):
-        with self.assertRaises(RuntimeError):
-            get_lodging_schema(self.event)
-    
+        schema = get_lodging_schema(self.event)
+        self.assertEqual(schema, None)
 
     def test_lodging_with_single_node(self):
         self.event.lodging_set.create(
@@ -178,10 +177,12 @@ class TestGetLodgingSchema(TestCase):
         )
 
         # make sure the lodging schema is built with one DB query
+        old_debug = settings.DEBUG
         settings.DEBUG=True
         reset_queries()
         schema = get_lodging_schema(self.event)
         self.assertEqual(len(connection.queries), 1)
+        settings.DEBUG=old_debug
 
         self.assertEqual(schema, {
             'title': 'Test Lodging',

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -153,6 +153,22 @@ class RegisterGetTests(APITestCase):
             },
         )
 
+        lodging_root = event.lodging_set.create(
+            name='Lodging',
+            children_title='Please choose a lodging option',
+            visible=True,
+        )
+        cabin = event.lodging_set.create(
+            name='Cabin',
+            parent=lodging_root,
+            visible=True,
+        )
+        tent = event.lodging_set.create(
+            name='Tent',
+            parent=lodging_root,
+            visible=True,
+        )
+
         response = self.client.get(f'/api/events/{event.id}/register')
         self.assertEqual(response.status_code, 200)
         jsonschema.Draft7Validator.check_schema(response.data['dataSchema'])
@@ -163,8 +179,20 @@ class RegisterGetTests(APITestCase):
                     'type': 'object',
                     'properties': {
                         'name': {'type': 'string'},
+                        'lodging': {
+                            'type': 'object',
+                            'title': 'Lodging',
+                            'properties': {
+                                'lodging_1': {
+                                    'title': 'Please choose a lodging option',
+                                    'enum': [cabin.id, tent.id],
+                                    'enumNames': ['Cabin', 'Tent'],
+                                }
+                            },
+                            'required': ['lodging_1'],
+                            'dependencies': {},
+                        },
                     },
-
                 },
             },
             'required': ['registrant_email'],


### PR DESCRIPTION
Generate a schema for lodging options based on the lodging tree. Renders as a series of `<select>` menus, where each selection causes the next menu to appear.

We still need to implement disabling options where there is no remaining capacity (see @evinism's comment below)