### PR TITLE
Implement user serializer

### DIFF
--- a/client/src/global.d.ts
+++ b/client/src/global.d.ts
@@ -10,6 +10,30 @@ type Template = any;
 // TODO: maybe get the backend team to auto-generate these types?
 
 declare global {
+  export interface ApiUser {
+    id: number;
+    date_joined: string;
+    email: string;
+    first_name: string;
+    groups: object[];
+    is_active: boolean;
+    is_staff: boolean;
+    is_superuser: boolean;
+    last_login: string;
+    last_name: string;
+    user_permissions: object[];
+    username: string;
+  }
+  export interface ApiAnonymousUser {
+    id: null;
+    groups: [];
+    is_active: false;
+    is_staff: false;
+    is_superuser: false;
+    last_login: null;
+    user_permissions: [];
+    username: '';
+  }
   export interface ApiEvent {
     id: number;
     created_at: string | null;

--- a/client/src/hooks/admin.ts
+++ b/client/src/hooks/admin.ts
@@ -9,14 +9,17 @@ import { useLocation } from 'react-router-dom';
  * This hook is not created via a factory, because it's value type is different
  * than all others.
  */
-export type UserInfo = {
-  email: string,
-  loggedIn: boolean,
-}
+export type UserInfo = ApiUser | ApiAnonymousUser;
 
-export const unauthenticatedUser = {
-  email: 'none',
-  loggedIn: false,
+export const unauthenticatedUser: ApiAnonymousUser = {
+  id: null,
+  groups: [],
+  is_active: false,
+  is_staff: false,
+  is_superuser: false,
+  last_login: null,
+  user_permissions: [],
+  username: '',
 };
 
 export const UserContext = React.createContext({

--- a/client/src/navigation/GuardedRoute.tsx
+++ b/client/src/navigation/GuardedRoute.tsx
@@ -12,7 +12,7 @@ function GuardedRoute({ children, ...rest }: Props) {
 
   return (
     <Route {...rest} render={(props) => (
-      user.loggedIn ? children : (
+      user.username ? children : (
         <Login
           onLoginSuccess={userInfo.set}
           onLoginFail={(e) => console.log(e)}

--- a/client/src/navigation/Login/index.tsx
+++ b/client/src/navigation/Login/index.tsx
@@ -57,8 +57,6 @@ class Login extends React.Component<LoginProps, LoginState> {
 
       const user = await response.json();
 
-      if (!user.loggedIn) throw new Error('login failed');
-
       this.setState({ processing: false });
 
       this.props.onLoginSuccess(user);

--- a/server/camphoric/views.py
+++ b/server/camphoric/views.py
@@ -72,7 +72,7 @@ class LoginView(APIView):
             password=request.data.get('password'))
         if user is not None:
             login(request, user)
-            return Response({'email': user.email, 'loggedIn': True})
+            return Response(serializers.UserSerializer(user).data)
 
         return Response({'detail': 'Login failed'}, status=400)
 
@@ -83,16 +83,11 @@ class LogoutView(APIView):
 
         return Response({'email': 'none', 'loggedIn': False})
 
-# TODO: create a user serializer so that we can have CRUDy users
-# see https://github.com/camphoric/camphoric/issues/133
+
 class UserView(APIView):
     def get(self, request):
-        user = self.request.user
+        return Response(serializers.UserSerializer(request.user).data)
 
-        if user.is_authenticated:
-            return Response({'email': user.email, 'loggedIn': True})
-
-        return Response({'email': 'none', 'loggedIn': False})
 
 class OrganizationViewSet(ModelViewSet):
     queryset = models.Organization.objects.all()

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -31,9 +31,12 @@ class LoginTests(APITestCase):
     def test_good_login(self):
         response = self.client.get('/api/user')
         self.assertEqual(response.status_code, 200)
-        self.assertJSONEqual(
-            str(response.content, encoding='utf8'),
-            {'email': 'none', 'loggedIn': False})
+        self.assertEqual(response.data['username'], '')
+        self.assertEqual(response.data['last_login'], None)
+        self.assertEqual(response.data['is_superuser'], False)
+        self.assertEqual(response.data['is_staff'], False)
+        self.assertEqual(response.data['is_active'], False)
+        self.assertNotIn('email', response.data)
 
         response = self.client.post(
             '/api/login',
@@ -42,11 +45,23 @@ class LoginTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.cookies['sessionid']['httponly'])
 
+        self.assertEqual(response.data['email'], 'tom@example.com')
+        self.assertEqual(response.data['first_name'], '')
+        self.assertEqual(response.data['is_active'], True)
+        self.assertEqual(response.data['is_staff'], True)
+        self.assertEqual(response.data['is_superuser'], True)
+        self.assertEqual(response.data['last_name'], '')
+        self.assertEqual(response.data['username'], 'tom')
+
         response = self.client.get('/api/user')
         self.assertEqual(response.status_code, 200)
-        self.assertJSONEqual(
-            str(response.content, encoding='utf8'),
-            {'email': 'tom@example.com', 'loggedIn': True})
+        self.assertEqual(response.data['email'], 'tom@example.com')
+        self.assertEqual(response.data['first_name'], '')
+        self.assertEqual(response.data['is_active'], True)
+        self.assertEqual(response.data['is_staff'], True)
+        self.assertEqual(response.data['is_superuser'], True)
+        self.assertEqual(response.data['last_name'], '')
+        self.assertEqual(response.data['username'], 'tom')
 
         response = self.client.get('/api/organizations/')
         self.assertEqual(response.status_code, 200)
@@ -62,6 +77,15 @@ class LoginTests(APITestCase):
 
         response = self.client.get('/api/organizations/')
         self.assertEqual(response.status_code, 401)
+
+        response = self.client.get('/api/user')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['username'], '')
+        self.assertEqual(response.data['last_login'], None)
+        self.assertEqual(response.data['is_superuser'], False)
+        self.assertEqual(response.data['is_staff'], False)
+        self.assertEqual(response.data['is_active'], False)
+        self.assertNotIn('email', response.data)
 
 
 class CSRFTests(APITestCase):


### PR DESCRIPTION
Changed login to return serialized user objects. Testing works for
serialized user objects. Frontend login to also expects entire
user objects.