### PR TITLE
Fix UI schema merge logic

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -57,5 +57,7 @@ jobs:
       - name: Install dependencies
         if: steps.cache-pipenv.outputs.cache-hit != 'true'
         run: pipenv install --deploy --dev
+      - name: Run flake8
+        run: pipenv run flake8
       - name: Run Tests
         run: pipenv run python manage.py test

--- a/server/camphoric/views.py
+++ b/server/camphoric/views.py
@@ -333,8 +333,16 @@ class RegisterView(APIView):
         ui_schema = {
             **event.registration_ui_schema,
             'campers': {
+                **event.registration_ui_schema.get('campers', {}),
                 'items': {
-                    'lodging': lodging_ui_schema,
+                    **event.registration_ui_schema.get('campers', {}).get('items', {}),
+                    'lodging': {
+                        **(event.registration_ui_schema
+                           .get('campers', {})
+                           .get('items', {})
+                           .get('lodging', {})),
+                        **(lodging_ui_schema or {}),
+                    }
                 },
             },
         }

--- a/server/camphoric_server/urls.py
+++ b/server/camphoric_server/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import include, path, re_path
+from django.urls import include, path
 from rest_framework.authtoken.views import obtain_auth_token
 
 urlpatterns = [

--- a/server/frontend_bootstrap/urls.py
+++ b/server/frontend_bootstrap/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path 
+from django.urls import re_path
 from . import views
 
 urlpatterns = [

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -223,6 +223,17 @@ class RegisterGetTests(APITestCase):
             registration_ui_schema={
                 'ui:title': 'Test UI Schema',
                 'ui:description': 'Test Description',
+
+                # to test that camper UI schema is merged correctly with lodging UI schema
+                'campers': {
+                    'ui:description': 'stuff about campers',
+                    'items': {
+                        'ui:description': 'stuff about a camper',
+                        'lodging': {
+                            'ui:description': 'stuff about lodging',
+                        },
+                    },
+                },
             }
         )
 
@@ -246,8 +257,11 @@ class RegisterGetTests(APITestCase):
             'ui:title': 'Test UI Schema',
             'ui:description': 'Test Description',
             'campers': {
+                'ui:description': 'stuff about campers',
                 'items': {
+                    'ui:description': 'stuff about a camper',
                     'lodging': {
+                        'ui:description': 'stuff about lodging',
                         'lodging_1': {
                             'ui:enumDisabled': [camp1.id],
                         },


### PR DESCRIPTION
The code for merging the lodging UI schema was overwriting the camper UI schema rather than merging the two.