### PR TITLE
Add list of events feature

### DIFF
--- a/client/src/components/Default.tsx
+++ b/client/src/components/Default.tsx
@@ -1,12 +1,35 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Container, Row, Col } from 'react-bootstrap';
+import Spinner from 'components/Spinner';
+
+type EventListItem = {
+  name: string,
+  open: boolean,
+  url: string,
+};
 
 function Splash(props: {}) {
+  const [eventList, setEventList] = React.useState<Array<EventListItem> | void>();
+
+  React.useEffect(() => {
+    fetch('/api/eventlist')
+      .then(r => r.json())
+      .then(setEventList);
+  }, []);
+
+  if (!eventList) return <Spinner />;
+
   return (
     <Container><Row className="justify-content-md-center"><Col>
       <h1>Camphoric!</h1>
-      <p><Link to="/events/1/register">Registration Page (event 1)</Link></p>
+      {
+        eventList.map((event: EventListItem) => (
+          <p key={event.url}>
+            <Link to={event.url}>{event.name} {!event.open ? "(closed)" : ""}</Link>
+          </p>
+        ))
+      }
       <p><Link to="/admin">Admin Page</Link></p>
     </Col></Row></Container>
   );

--- a/data/loadAllData.mjs
+++ b/data/loadAllData.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import loadLark from './lark/LoadData';
-import loadLarkCampout from './lark_campout/LoadData';
+import loadLark from './lark/LoadData.mjs';
+import loadLarkCampout from './lark_campout/LoadData.mjs';
 
 main();
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - db:/var/lib/postgresql/data/pgdata
     healthcheck:
-      test: [ "CMD-SHELL", "runuser", "-c", "$POSTGRES_USER", "-c", "/usr/bin/pg_isready" ]
+      test: [ "CMD-SHELL", "runuser", "-c", "$$POSTGRES_USER", "-c", "/usr/bin/pg_isready" ]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -22,7 +22,6 @@ services:
   django:
     env_file:
       - ./env/local/shared.env
-      - ./env/local/postgres.env
       - ./env/local/django.env
     build: server/
     volumes:

--- a/reset-db
+++ b/reset-db
@@ -44,6 +44,7 @@ then
     done
 fi
 
+docker compose exec django python manage.py migrate
 docker compose exec django python manage.py flush --noinput
 docker compose exec django python manage.py createsuperuser --noinput
 docker compose exec react node fixtures/loadAllData.mjs

--- a/server/camphoric/models.py
+++ b/server/camphoric/models.py
@@ -1,4 +1,5 @@
 import random
+import datetime
 
 from decimal import Decimal
 
@@ -125,6 +126,18 @@ class Event(TimeStampedModel):
 
     def __str__(self):
         return self.name
+
+    def is_open(self):
+        open = False
+        now = timezone.now()
+        long_ago = datetime.datetime(1979, 1, 1, tzinfo=timezone.get_current_timezone())
+        far_future = datetime.datetime(2400, 1, 1, tzinfo=timezone.get_current_timezone())
+
+        registration_start = self.registration_start or long_ago
+        registration_end = self.registration_end or far_future
+        if (now >= registration_start and now < registration_end):
+            open = True
+        return open
 
 
 class RegistrationType(TimeStampedModel):

--- a/server/camphoric/urls.py
+++ b/server/camphoric/urls.py
@@ -29,5 +29,10 @@ urlpatterns = router.urls + [
         views.RegisterView.as_view(),
         name='register',
     ),
+    path(
+        'eventlist',
+        views.EventList.as_view(),
+        name='eventlist',
+    ),
     path('invitations/<int:invitation_id>/send', views.SendInvitationView.as_view()),
 ]

--- a/server/camphoric/views.py
+++ b/server/camphoric/views.py
@@ -187,6 +187,26 @@ class InvitationError(Exception):
         self.user_message = user_message
 
 
+class EventList(APIView):
+    def get(self, request):
+        '''
+        Return an array of objects with the following keys:
+        - name: event name
+        - url: url to the registration form for the event
+        - open: whether registration is open for this event
+        '''
+        events = models.Event.objects.all()
+
+        def map_event(event):
+            return {
+                'name': event.name,
+                'url': f"/events/{event.id}/register",
+                'open': event.is_open(),
+            }
+        response_data = list(map(map_event, events))
+        return Response(response_data)
+
+
 class RegisterView(APIView):
     def get(self, request, event_id=None, format=None):
         '''

--- a/server/tests/test_models.py
+++ b/server/tests/test_models.py
@@ -63,3 +63,49 @@ class LodgingTests(TestCase):
 
     def test_lodging_default_blank(self):
         self.assertEqual(self.lodging.notes, '')
+
+
+class EventTests(TestCase):
+    def setUp(self):
+        self.organization = models.Organization.objects.create()
+
+    def test_is_open(self):
+        one_day = datetime.timedelta(days=1)
+        long_ago = datetime.datetime(1979, 2, 25, tzinfo=timezone.get_current_timezone())
+        far_future = datetime.datetime(2479, 2, 25, tzinfo=timezone.get_current_timezone())
+        now = timezone.now()
+
+        event = models.Event.objects.create(
+                organization=self.organization,
+                registration_start=None,
+                registration_end=None,
+            )
+        self.assertEqual(event.is_open(), True, msg='when start/end is none it defaults to open')
+
+        event = models.Event.objects.create(
+                organization=self.organization,
+                registration_start=long_ago,
+                registration_end=far_future,
+            )
+        self.assertEqual(event.is_open(), True)
+
+        event = models.Event.objects.create(
+                organization=self.organization,
+                registration_start=now + one_day,
+                registration_end=far_future,
+            )
+        self.assertEqual(event.is_open(), False)
+
+        event = models.Event.objects.create(
+                organization=self.organization,
+                registration_start=long_ago,
+                registration_end=now - one_day,
+            )
+        self.assertEqual(event.is_open(), False)
+
+        event = models.Event.objects.create(
+                organization=self.organization,
+                registration_start=now + one_day,
+                registration_end=now - one_day,
+            )
+        self.assertEqual(event.is_open(), False)

--- a/server/tests/test_views.py
+++ b/server/tests/test_views.py
@@ -130,6 +130,38 @@ class CSRFTests(APITestCase):
         self.assertEqual(response.status_code, 400)
 
 
+class EventListGetTests(APITestCase):
+    def setUp(self):
+        self.organization = models.Organization.objects.create(name='Test Organization')
+        models.Event.objects.create(
+                organization=self.organization,
+                name='Test Data Event 1',
+                registration_schema={
+                    'type': 'object',
+                    'properties': {
+                        'billing_name': {'type': 'string'},
+                        'billing_address': {'type': 'string'},
+                        },
+                    },
+
+                camper_schema={
+                    'type': 'object',
+                    'properties': {
+                        'name': {'type': 'string'},
+                        },
+                    },
+                )
+
+    def test_get(self):
+        response = self.client.get('/api/eventlist')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, [{
+            'name': 'Test Data Event 1',
+            'open': True,
+            'url': '/events/18/register',
+        }])
+
+
 class RegisterGetTests(APITestCase):
     def setUp(self):
         self.organization = models.Organization.objects.create(name='Test Organization')


### PR DESCRIPTION
This adds:

- A method to the Event model which checks if the event's registration is open
- A new api endpoint that lists the current events and if they're open
- Rework the root react view so that it lists the events and links to their
  registration pages

<img width="351" alt="Screen Shot 2022-06-26 at 5 46 52 PM" src="https://user-images.githubusercontent.com/15619556/175841198-53facf27-9dc4-44e0-9ee6-9c5e8e5d3212.png">

It also adds these quick fixes:

- Fix health check for docker postgres
- Fix reset script
