### PR TITLE
Fall back to email account defaults in loadOrganizations

### DIFF
--- a/data/loadOrganizations.mjs
+++ b/data/loadOrganizations.mjs
@@ -19,19 +19,37 @@ async function loadOrganization(name, token) {
   let org = organizations.find(o => o.name === name);
   if (!org) {
     console.log(`Could not find '${name}' organization, creating`);
-    org = await fetch(`${urlBase}/api/organizations/`, {
+    let response = await fetch(`${urlBase}/api/organizations/`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Token ${token}`,
       },
       body: JSON.stringify({ name }),
-    }).then(res => res.json());
+    });
+    if (!response.ok) {
+      throw new Error(`error creating organization: ${await response.text()}`);
+    }
+
+    org = await response.json();
 
 		console.log(`'${name}' organization created!`);
 
     console.log(`creating email account for '${name}'`);
-    const email = await fetch(`${urlBase}/api/emailaccounts/`, {
+
+    const creds = {};
+    [
+      ['username', 'CAMPHORIC_TEST_GMAIL_USERNAME', 'nobody@example.com'],
+      ['password', 'CAMPHORIC_TEST_GMAIL_PASSWORD', 'abc123'],
+    ].forEach(([field, variable, defaultValue]) => {
+      creds[field] = process.env[variable];
+      if (!creds[field]) {
+        console.warn(`${variable} not set in env, using default value ${defaultValue}`);
+        creds[field] = defaultValue;
+      }
+    });
+
+    response = await fetch(`${urlBase}/api/emailaccounts/`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -42,10 +60,12 @@ async function loadOrganization(name, token) {
         name: 'Test gmail account',
         host: 'smtp.gmail.com',
         port: '587',
-        username: process.env.CAMPHORIC_TEST_GMAIL_USERNAME,
-        password: process.env.CAMPHORIC_TEST_GMAIL_PASSWORD,
+        ...creds,
       }),
-    }).then(res => res.text());
+    });
+    if (!response.ok) {
+      throw new Error(`error creating email account: ${await response.text()}`);
+    }
   }
 
   return org;


### PR DESCRIPTION
- log and exit on API error response to help with debugging
- use default values for email account env variables in case they are not set

This gets `loadAllData.mjs` working for me. I didn't figure why these two environment variables were not set despite being set in env/local/shared.env. @willfulbard, any thoughts?