### PR TITLE
Create better lodging interface

### DIFF
--- a/client/src/components/JsonSchemaForm/fields/LodgingRequested/LodgingRequested.tsx
+++ b/client/src/components/JsonSchemaForm/fields/LodgingRequested/LodgingRequested.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { FieldProps } from '@rjsf/core';
+
+import LodgingSelect from './LodgingSelect';
+
+export type LodgingNode = {
+  id: number,
+  event: number,
+  parent: number | null,
+  name: string,
+  children_title: string,
+  capacity: number,
+  reserved: number,
+  camper_count_adjusted: number,
+  remaining_unreserved_capacity: number,
+  visible: boolean,
+  sharing_multiplier: number,
+  notes: string,
+};
+
+export type ChildLodgingNode = LodgingNode & {
+  parent: number,
+};
+
+export type RootLodgingNode = LodgingNode & {
+  parent: null,
+};
+
+export type LodgingArray = Array<LodgingNode>;
+
+function LodgingRequestedField(props: FieldProps) {
+  const nodes = props.uiSchema.lodging_nodes as LodgingArray;
+  const root = nodes.find((n) => !n.parent) as RootLodgingNode;
+  const choices = props.formData.choices?.filter(Boolean) || [] as Array<number>;
+
+  console.log('LodgingRequestedField props', props);
+
+  const isLeaf = (id: number) => 
+    !nodes.find(n => n.parent === id);
+
+  const onValueChange = (value: number, index: number) => {
+    const newChoices = [
+      ...choices.slice(0, index),
+      value,
+    ];
+
+    const name = nodes.find(n => n.id === value)?.name;
+
+    const newFormData = {
+      id: isLeaf(value) ? value : undefined, 
+      name: isLeaf(value) ? name : undefined, 
+      choices: newChoices,
+    };
+
+    console.log('LodgingRequestedField onChange value', newFormData);
+
+    props.onChange(newFormData);
+  };
+
+  return (
+    <div
+      id="field-lodging-requested-container"
+      className="field-lodging-requested"
+    >
+      <LodgingSelect
+        fieldProps={props}
+        node={root}
+        nodes={nodes}
+        value={choices[0]}
+        onValueChange={onValueChange}
+        index={0}
+      />
+      {
+        choices
+        .map((nid: number) => nodes.find(n => n.id === nid))
+        .map(
+          (n: LodgingNode, i: number) => {
+            if (isLeaf(n.id)) return null;
+
+            return (
+              <LodgingSelect
+                key={n.id}
+                fieldProps={props}
+                node={n}
+                nodes={nodes}
+                value={choices[i + 1]}
+                onValueChange={onValueChange}
+                index={i + 1}
+              />
+            );
+          }
+        )
+      }
+    </div>
+  );
+}
+
+export default LodgingRequestedField;

--- a/client/src/components/JsonSchemaForm/fields/LodgingRequested/LodgingSelect.tsx
+++ b/client/src/components/JsonSchemaForm/fields/LodgingRequested/LodgingSelect.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { FieldProps } from '@rjsf/core';
+import type {
+  LodgingNode,
+  LodgingArray,
+} from './LodgingRequested';
+
+type Props = {
+  node: LodgingNode,
+  nodes: LodgingArray,
+  onValueChange: (a: number, i: number) => void,
+  value: number | undefined,
+  fieldProps: FieldProps,
+  index: number,
+};
+
+function LodgingSelect(props: Props) {
+  const { SelectWidget } = props.fieldProps.registry.widgets;
+
+  const options = {
+    enumOptions: props.nodes
+      .filter(n => n.parent === props.node.id)
+      .map(n => {
+        let label = n.name;
+
+        // label full if no remaining capacity
+        if (n.remaining_unreserved_capacity  <= 0) {
+          label = `${n.name} (full)`;
+        }
+
+        return {
+          label,
+          value: n.id,
+        };
+      }),
+    // disable option if no remaining capacity
+    enumDisabled: props.nodes
+      .filter(n => (n.remaining_unreserved_capacity  <= 0))
+      .map(n => n.id),
+    emptyValue: '',
+  }
+
+  const baseId = props.fieldProps.idSchema.choices.$id;
+
+  return (
+    <SelectWidget
+      {...props.fieldProps}
+      placeholder={props.node.children_title || ''}
+      id={`${baseId}_${props.node.id}`}
+      label={' '}
+      value={props.value}
+      onChange={(v) => props.onValueChange(Number(v), props.index)}
+      options={options}
+      rawErrors={[]}
+      multiple={false}
+    />
+  );
+}
+
+export default LodgingSelect;

--- a/client/src/components/JsonSchemaForm/fields/LodgingRequested/index.ts
+++ b/client/src/components/JsonSchemaForm/fields/LodgingRequested/index.ts
@@ -1,0 +1,3 @@
+import LodgingRequested from './LodgingRequested';
+
+export default LodgingRequested;

--- a/client/src/components/JsonSchemaForm/index.tsx
+++ b/client/src/components/JsonSchemaForm/index.tsx
@@ -18,6 +18,7 @@ import ArrayTemplate from './templates/Array';
 import DescriptionField from './fields/Description';
 import CampersField from './fields/Campers';
 import AddressField from './fields/Address';
+import LodgingRequestedField from './fields/LodgingRequested';
 
 import NaturalNumberInput from './widgets/NaturalNumberInput';
 import PhoneInput from './widgets/PhoneInput';
@@ -48,6 +49,7 @@ Bootstrap4Theme.fields = {
   // The typedefs of rjsf are still being refined
   // @ts-expect-error
   Address: AddressField,
+  LodgingRequested: LodgingRequestedField,
 };
 
 const Form = withTheme(Bootstrap4Theme);

--- a/client/src/pages/Register/index.tsx
+++ b/client/src/pages/Register/index.tsx
@@ -68,8 +68,15 @@ export type RegistrationState =
   | SubmittedState
   | SubmissionErrorState;
 
-const localStorageKey = 'formData';
-const saveFormDataToLocalStorage = debounce((formData) => {
+const getLocalStorageKey = (config: ApiRegister) => {
+  const name = config.dataSchema.title || 'formData';
+  const date = config.event.start;
+
+  return `${name}, ${date.year}-${date.month}-${date.day}`;
+}
+
+const saveFormDataToLocalStorage = debounce((formData, config) => {
+  const localStorageKey = getLocalStorageKey(config);
   debug('saving form data');
   try {
     localStorage.setItem(localStorageKey, JSON.stringify(formData));
@@ -153,6 +160,7 @@ class App extends React.Component<Props, RegistrationState> {
         confirmationProps,
       });
 
+      const localStorageKey = getLocalStorageKey(this.state.config);
       localStorage.removeItem(localStorageKey)
     } catch {
       this.setState({ status: "submissionError" });
@@ -191,9 +199,10 @@ class App extends React.Component<Props, RegistrationState> {
     });
   };
 
-  getSavedFormData = () => {
+  getSavedFormData = (config: ApiRegister) => {
     // check if form data has been saved in local storage
     let formData = { campers: [{}] };
+    const localStorageKey = getLocalStorageKey(config);
 
     try {
       const saved = localStorage.getItem(localStorageKey);
@@ -226,7 +235,7 @@ class App extends React.Component<Props, RegistrationState> {
       return;
     }
 
-    const formData = this.getSavedFormData();
+    const formData = this.getSavedFormData(config);
 
     this.setState({
       status: "loaded",
@@ -252,7 +261,7 @@ class App extends React.Component<Props, RegistrationState> {
     debug('onChange', data);
 
     this.setState(data);
-    saveFormDataToLocalStorage(data.formData);
+    saveFormDataToLocalStorage(data.formData, this.state.config);
   };
 
   onJsonSchemaFormError = (errors: Array<any>) => {

--- a/data/lark/camperMeals.js
+++ b/data/lark/camperMeals.js
@@ -12,7 +12,7 @@ const dependencies = {
       {
         'properties': {
           'meal_plan': {
-            'enum': ['', 'None']
+            'enum': ['None']
           }
         }
       },
@@ -31,6 +31,21 @@ const dependencies = {
     ]
   }
 };
+
+const allOf = [
+  {
+    if: { properties: { meal_plan: { enum: Object.values(mealsLookup) } } },
+    then: {
+      properties: {
+        meal_type: {
+          type: 'string',
+          title: 'What types of meals do you want?',
+          enum: mealTypes,
+        }
+      }
+    }
+  }
+];
 
 const createMeals = (...options) => ({
   'type': 'object',
@@ -54,10 +69,10 @@ Meal plans offer significant savings. You may buy individual meals at camp inste
         'None',
         ...options.map(o => mealsLookup[o])
       ],
-      'default': ''
+      'default': 'None'
     }
   },
-  'dependencies': dependencies,
+  dependencies,
 });
 
 export default createMeals;

--- a/data/lark/camperSchema.js
+++ b/data/lark/camperSchema.js
@@ -37,11 +37,6 @@ export default {
       'oneOf': [
         {
           'properties': {
-            'session': { enum: [''] },
-          }
-        },
-        {
-          'properties': {
             'session': { enum: [sessionTypes.F] },
             'meals': meals('F', 'D'),
           }

--- a/data/lark/testRegistrations.js
+++ b/data/lark/testRegistrations.js
@@ -94,9 +94,11 @@ function makeRegistration(reg, lodgingMap) {
         'session': 'Full camp',
         'address_different_than_payer': false,
         'lodging': {
-          'lodging_1': lodgingMap[c[4]].id,
-          'lodging_2': lodgingMap[c[5]].id,
-          'lodging_3': lodgingMap[c[6]].id,
+          'lodging_requested': {
+            'choices': [ lodgingMap[c[4]].id, lodgingMap[c[5]].id, lodgingMap[c[6]].id ],
+            'id': lodgingMap[c[6]].id,
+            'name': 'Something',
+          },
           ...(c[8] ?  { lodging_shared: true, lodging_shared_with: c[8].id } : {})
         },
         'first_name': c[2],

--- a/data/lark_campout/testRegistrations.js
+++ b/data/lark_campout/testRegistrations.js
@@ -71,7 +71,11 @@ function destructureCamper(c, email, phone, lodgingMap) {
     phone,
     vaccination_status: vax === 'mrna' ? mrna : trad,
     lodging: {
-      lodging_1: lodgingMap[lodging].id,
+      'lodging_requested': {
+        'choices': [ lodgingMap[lodging].id ],
+        id: lodgingMap[lodging].id,
+        'name': 'Something',
+      },
       ...(
         !lodging_shared_with ? {} : {
           lodging_shared_with,

--- a/server/camphoric/views.py
+++ b/server/camphoric/views.py
@@ -512,38 +512,16 @@ class RegisterView(APIView):
     def deserialize_camper(cls, registration, camper_data):
         '''
         Transform a dict from the `campers` list in the form data into a Camper
-        model instance. The trickiest thing this does is to determine the
-        lodging_id. `camper_data` looks something like this:
-
-            {
-                # camper attributes corresponding to event.camper_schema, e.g.
-                'name': 'John',
-                'age': 12,
-
-                # lodging selection, not part of event.camper_schema
-                'lodging': {
-                    'lodging_1': 17,
-                    'lodging_2': 20,
-                    'lodging_3': 25
-                    'lodging_shared': True,
-                    'lodging_shared_with': 'my buddy',
-                    'lodging_comments': 'my buddy and me',
-                }
-            }
-
-        Each item in the `lodging` dict whose key has a numeric suffix is a
-        selection along the lodging tree. The one with the highest number is the
-        final selection.
+        model instance. The biggest thing this does is to transform the lodging
+        data into a form that can be saved into the model.
         '''
 
         lodging_data = {}
+        lodging_id = None
         if 'lodging' in camper_data:
             lodging_data = camper_data['lodging']
+            lodging_id = lodging_data['lodging_requested']['id']
             del camper_data['lodging']
-
-        matches = [re.match(r'^lodging_([0-9]+)$', key) for key in lodging_data.keys()]
-        depths = [int(match.group(1)) for match in matches if match]
-        lodging_id = lodging_data[f'lodging_{max(depths)}'] if len(depths) else None
 
         return models.Camper(
             registration=registration,


### PR DESCRIPTION
- Create custom lodging component
  - This component allows us to control lodging selection on the front end, while keeping the schema simple
- Add custom local storage key per event
  - I was seeing a little bit of data conflict between the lark campout data from an unsubmitted registration and the new lark camp event.  This should prevent conflicts, basically siloing the local storage to a specific event + start date
- Create better serialization of data
  - "better" is probably not the right word, more like just getting it working.
- Fix tests
  - Some of the tests were simplified, and might just need to be removed, since the backend logic is greatly simplified

TODO:

There's a lot of code cleanup to do in the lodging department.  Most of the tree stuff can probably be ripped out, but I would prefer if @brsaylor did it since he's more familiar.
