### PR TITLE
Add helpers for reports

### DIFF
--- a/client/src/components/Template/handlebarsHelpers.ts
+++ b/client/src/components/Template/handlebarsHelpers.ts
@@ -35,6 +35,67 @@ const comparison = (a, b) => {
 };
 
 const helpers: HelperHash = {
+  getLodgingValue: [
+    `
+    {{getLodgingValue lodging 'name'}}
+    Tent spot A
+    Lookup a lodging object and return a value from a path
+    `,
+    function (lodgingId, path, options) {
+      console.log(options.data.root);
+      const lookup = options.data.root.lodgingLookup;
+      const reg = lookup[lodgingId];
+
+      if (!reg) return '';
+
+      const value = getFromPath(reg, path);
+
+      if (value === undefined) return '';
+
+      return value;
+    },
+  ],
+
+  getRegistrationValue: [
+    `
+    {{getRegistrationValue camper.registration 'initial_payment.total'}}
+    9999
+    Lookup a registration object and return a value from a path
+    `,
+    function (registrationId, path, options) {
+      const lookup = options.data.root.registrationLookup;
+      const reg = lookup[registrationId];
+
+      if (!reg) return '';
+
+      const value = getFromPath(reg, path);
+
+      if (value === undefined) return '';
+
+      return value;
+    },
+  ],
+
+  getCamperValue: [
+    `
+    {{getCamperValue campers.0.id 'attributes.first_name'}}
+    bob
+    Lookup a camper object and return a value from a path
+    `,
+    function (camperId, path, options) {
+      const lookup = options.data.root.camperLookup;
+      const reg = lookup[camperId];
+
+      if (!reg) return '';
+
+      const value = getFromPath(reg, path);
+
+      if (value === undefined) return '';
+
+      return value;
+    },
+  ],
+
   compare: [
     `
     {{compare myStr '===' 'bob'}}bob{{/compare}}
@@ -105,6 +166,7 @@ const helpers: HelperHash = {
       return abs;
     }
   ],
+
   or: [
     `
     {{or false 0 bob}}
@@ -177,6 +239,35 @@ const helpers: HelperHash = {
     function(arr, path) {
       return arr.map(i => getFromPath(path))
         .reduce((acc, n) => acc + (Number(n) || 0), 0);
+    }
+  ],
+
+  eachLookupSort: [
+    `
+    {{#eachLookupSort campers 'lodging' 'lodgingLookup' 'name'}}{{attributes.name}},{{/eachLookupSort}}
+    Abby,Bob,Jane,Zed,
+    Block helper that sorts an array of objects by a value found in a lookup
+    `,
+    function(arr, objKey, lookupName, lookupValueKey, options) {
+      console.log(options);
+      const lookup = options.data.root[lookupName];
+
+      if (!lookup) {
+        console.error(`can't find lookup '${lookupName}`);
+        return '';
+      }
+
+      const arrSorted =  arr.sort((a, b) => {
+        const akey = getFromPath(a, objKey);
+        const bkey = getFromPath(b, objKey);
+
+        const aval = getFromPath(lookup[akey], lookupValueKey);
+        const bval = getFromPath(lookup[bkey], lookupValueKey);
+
+        return comparison(aval, bval);
+      });
+
+      return arrSorted.map(options.fn).join('');
     }
   ],
 

--- a/client/src/global.d.ts
+++ b/client/src/global.d.ts
@@ -245,6 +245,7 @@ declare global {
     isLeaf: boolean;
     campers: Array<ApiCamper>;
     count: number;
+    fullPath: string;
   }
 }
 

--- a/client/src/hooks/api.ts
+++ b/client/src/hooks/api.ts
@@ -361,6 +361,18 @@ export function useLodgingTree(): AugmentedLodging | undefined {
 
     const allCampers = Object.values(camperLookup);
 
+    const getFullPath = (lodging: ApiLodging | undefined, pathParts: string[] = []): string => {
+      if (!lodging || !lodging.parent) {
+        return pathParts.reverse().join('→') || '';
+      }
+
+      return getFullPath(
+        lodgingsAll.find(l => l.id.toString() === lodging.parent.toString()),
+        [...pathParts, lodging.name],
+      );
+
+    };
+
     const createNode = (lodging: ApiLodging): AugmentedLodging => {
       const children: Array<AugmentedLodging> = lodgingsAll
         .filter(l => l.parent === lodging.id)
@@ -377,6 +389,8 @@ export function useLodgingTree(): AugmentedLodging | undefined {
       );
       const isLeaf = children.length === 0;
 
+      const fullPath = getFullPath(lodging);
+
       return {
         ...lodging,
         isLeaf,
@@ -384,8 +398,9 @@ export function useLodgingTree(): AugmentedLodging | undefined {
         count,
         campers,
         capacity,
+        fullPath,
       };
-    }
+    };
 
     setTree(createNode(lodgingRoot));
   }, [lodgingsAllApi, event, camperLookup]);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ volumes:
 
 services:
   postgres:
-    image: postgres:13
+    image: postgres:14
     env_file:
       - ./env/local/shared.env
       - ./env/local/postgres.env


### PR DESCRIPTION
- Bump postgres version to 14
- Add fullPath string to lodging lookup
- Add some new helpers

Here is an example of how some of the new helpers could be used:

```
| Last Name | First Name | Age | Lodging | Chore |
| --------- | ---------- | --- | ------- | ----- |
{{#eachLookupSort campers 'lodging' 'lodgingLookup' 'fullPath'}}
| {{this.attributes.last_name}} | {{this.attributes.first_name}} | {{this.attributes.age}} | {{getLodgingValue lodging 'fullPath'}}  | {{this.attributes.chore}} |
{{/eachLookupSort}}
```

Result:


<img width="680" alt="Screenshot 2023-06-25 at 5 47 04 PM" src="https://github.com/camphoric/camphoric/assets/15619556/f0b3f168-5e45-4a8f-bc61-003b526e1836">

