### PR TITLE
Add download button for json data

### DIFF
--- a/client/src/components/Template/Template.tsx
+++ b/client/src/components/Template/Template.tsx
@@ -2,6 +2,21 @@ import React from 'react';
 import { template2Html } from './util';
 import debug from 'utils/debug';
 
+import {
+  CamperLookup,
+  LodgingLookup,
+  RegistrationLookup,
+} from 'hooks/api';
+
+export interface ReportTemplateVars {
+  event: ApiEvent;
+  registrationLookup: RegistrationLookup | undefined;
+  registrations: Array<AugmentedRegistration>;
+  camperLookup: CamperLookup | undefined;
+  lodgingLookup: LodgingLookup | undefined;
+  campers: Array<ApiCamper>;
+}
+
 interface Props {
   markdown?: string;
   templateVars?: {};

--- a/client/src/components/Template/index.ts
+++ b/client/src/components/Template/index.ts
@@ -1,4 +1,5 @@
 import Template from './Template';
 import './styles.scss';
 
+export * from './Template';
 export default Template;

--- a/client/src/components/TemplateHelp/HelperDocs.tsx
+++ b/client/src/components/TemplateHelp/HelperDocs.tsx
@@ -24,7 +24,7 @@ function HelperDocs() {
             ] = help.trim().split(/\r?\n/);
 
             return (
-              <Card>
+              <Card key={key}>
                 <Card.Body>
                   <Card.Title>{key}</Card.Title>
                   <Card.Text>

--- a/client/src/components/TemplateHelp/TemplateHelp.tsx
+++ b/client/src/components/TemplateHelp/TemplateHelp.tsx
@@ -6,17 +6,15 @@ import {
   Tab,
 } from 'react-bootstrap';
 
-import Template from 'components/Template';
+import Template, { ReportTemplateVars } from 'components/Template';
 import JsonEditor from 'components/JsonEditor';
 import Modal from 'components/Modal';
 
 import helpText from './helpText';
 import HelperDocs from './HelperDocs';
 
-import './styles.scss';
-
 interface Props {
-  templateVars: Object,
+  templateVars: ReportTemplateVars,
 }
 
 class TemplateHelp extends React.Component<Props> {
@@ -24,6 +22,16 @@ class TemplateHelp extends React.Component<Props> {
 
   close = () => this.modalRef?.current?.close();
   show = () => this.modalRef?.current?.show();
+
+  downloadFile = () => {
+    const fileData = JSON.stringify(this.props.templateVars, null, 2);
+    const element = document.createElement('a');
+    const file = new Blob([fileData], { type: 'application/json' });
+    element.href = URL.createObjectURL(file);
+    element.download = `${this.props.templateVars.event.name} Data.json`;
+    document.body.appendChild(element);
+    element.click();
+  }
 
   render() {
     return (
@@ -47,7 +55,11 @@ class TemplateHelp extends React.Component<Props> {
             <Tab className="template-help-modal-helpers" eventKey="Helpers" title="Helpers">
               <HelperDocs />
             </Tab>
-            <Tab eventKey="Variables" title="Variables">
+            <Tab className="template-help-modal-helpers" eventKey="Variables" title="Variables">
+              <div className="button-container">
+                <input id="jsonInput" type="hidden" />
+                <Button onClick={this.downloadFile}>Download Template Data as JSON</Button>
+              </div>
               <JsonEditor
                 json={this.props.templateVars}
               />

--- a/client/src/components/TemplateHelp/index.ts
+++ b/client/src/components/TemplateHelp/index.ts
@@ -1,3 +1,5 @@
 import TemplateHelp from './TemplateHelp';
 
+import './styles.scss';
+
 export default TemplateHelp;

--- a/client/src/components/TemplateHelp/styles.scss
+++ b/client/src/components/TemplateHelp/styles.scss
@@ -3,6 +3,10 @@
     margin: 1rem;
   }
 
+  .button-container {
+    margin-bottom: 1rem;
+  }
+
   .helper-description {
     margin-bottom: 1rem;
   }

--- a/client/src/pages/EventAdminReports/EventAdminReports.tsx
+++ b/client/src/pages/EventAdminReports/EventAdminReports.tsx
@@ -10,11 +10,9 @@ import {
 } from 'react-bootstrap';
 import { useQueryLookup } from 'hooks/navigation';
 import Modal from 'components/Modal';
+import { ReportTemplateVars } from 'components/Template';
 
 import api, {
-  CamperLookup,
-  LodgingLookup,
-  RegistrationLookup,
   useCamperLookup,
   useEvent,
   useLodgingLookup,
@@ -26,16 +24,6 @@ import api, {
 import ReportSearchResult from './ReportSearchResult';
 import ReportTab from './ReportTab';
 import ReportEditForm, { ReportEditFormValue } from './ReportEditForm';
-
-export interface ReportTemplateVars {
-  event: ApiEvent;
-  registrationLookup: RegistrationLookup | undefined;
-  registrations: Array<AugmentedRegistration>;
-  camperLookup: CamperLookup | undefined;
-  lodgingLookup: LodgingLookup | undefined;
-  campers: Array<ApiCamper>;
-}
-
 
 const blankForm = {
   title: '',

--- a/client/src/pages/EventAdminReports/ReportEditForm.tsx
+++ b/client/src/pages/EventAdminReports/ReportEditForm.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import Input, { TextArea } from 'components/Input';
 import TemplateHelp from 'components/TemplateHelp';
-
-import type { ReportTemplateVars } from './EventAdminReports';
+import type { ReportTemplateVars } from 'components/Template';
 
 export type ReportEditFormValue = {
   title: string,

--- a/client/src/pages/EventAdminReports/ReportTab.tsx
+++ b/client/src/pages/EventAdminReports/ReportTab.tsx
@@ -5,9 +5,7 @@ import {
   Tab,
 } from 'react-bootstrap';
 import ReportEditForm, { ReportEditFormProps, ReportEditFormValue } from './ReportEditForm';
-import Template from 'components/Template';
-
-import type { ReportTemplateVars } from './EventAdminReports';
+import Template, { ReportTemplateVars } from 'components/Template';
 
 interface Props extends ReportEditFormProps {
   save: () => any;


### PR DESCRIPTION
Adds the ability to download raw JSON data that is used in templates.  This will aid in us transitioning away from handlebars templates.

Eventually we'll probably use https://pypi.org/project/jinja-cli/

<img width="512" alt="Screenshot 2023-06-29 at 5 41 01 PM" src="https://github.com/camphoric/camphoric/assets/15619556/cde9e54b-fc6b-4ebe-aefd-60d949123120">
