### PR TITLE
More Camp Harmony fixes

### DIFF
--- a/data/harmony/camperSchema.js
+++ b/data/harmony/camperSchema.js
@@ -6,9 +6,10 @@ export const days = [
   'Sun Dec 31',
 ];
 
+// export default (args) => ({
 export default {
   'type': 'object',
-  'required': ['first_name', 'last_name', 'email', 'phone', 'attendance', 'campership_request'],
+  'required': ['first_name', 'last_name', 'email', 'phone', 'attendance'],
   'properties': {
     'first_name': {
       'type': 'string',
@@ -94,5 +95,31 @@ applied.`,
       'minimum': 0,
       'default': 0,
     },
-  }
+  },
+  //   'if': {
+  //     'properties': {
+  //       'lodging': {
+  //         'type': 'object',
+  //         'properties': {
+  //           'lodging_requested': {
+  //             'type': 'object',
+  //             'properties': {
+  //               'choices': {
+  //                 'contains': {
+  //                   'const': 5,
+  //                 }
+  //               },
+  //             },
+  // 
+  //           },
+  //         },
+  //       },
+  //     },
+  //   },
+  //   'then': {
+  //     'properties': { 'postal_code': { 'pattern': '[0-9]{5}(-[0-9]{4})?' } }
+  //   },
+  //   'else': {
+  //     'properties': { 'postal_code': { 'pattern': '[A-Z][0-9][A-Z] [0-9][A-Z][0-9]' } }
+  //   }
 };

--- a/data/harmony/camperSchema.js
+++ b/data/harmony/camperSchema.js
@@ -66,6 +66,19 @@ export default {
       ],
       'default': 'Omnivore',
     },
+    'linens': {
+      'title': 'Sheet rental',
+      'description': `
+All campers should bring bedding (blankets, sleeping bag, pillow, etc).
+Camp Newman is able to provide fitted and top sheets for an additional $25.
+Would you like to rent sheets?`,
+      'type': 'string',
+      'enum': [
+        'Yes',
+        'No',
+      ],
+      'default': 'No',
+    },
     'meal_exceptions': {
       'title': 'Dietary Needs',
       'type': 'array',
@@ -96,30 +109,4 @@ applied.`,
       'default': 0,
     },
   },
-  //   'if': {
-  //     'properties': {
-  //       'lodging': {
-  //         'type': 'object',
-  //         'properties': {
-  //           'lodging_requested': {
-  //             'type': 'object',
-  //             'properties': {
-  //               'choices': {
-  //                 'contains': {
-  //                   'const': 5,
-  //                 }
-  //               },
-  //             },
-  // 
-  //           },
-  //         },
-  //       },
-  //     },
-  //   },
-  //   'then': {
-  //     'properties': { 'postal_code': { 'pattern': '[0-9]{5}(-[0-9]{4})?' } }
-  //   },
-  //   'else': {
-  //     'properties': { 'postal_code': { 'pattern': '[A-Z][0-9][A-Z] [0-9][A-Z][0-9]' } }
-  //   }
 };

--- a/data/harmony/confirmationEmailTemplate.js
+++ b/data/harmony/confirmationEmailTemplate.js
@@ -6,30 +6,42 @@ Dear {{campers.0.first_name}} {{campers.0.last_name}},
 
 Thank you for your online registration for Camp Harmony ${yearDisplay}! This email confirms the following:
 
-You have registered the following campers:
-
+Registration Info
 {{#campers}}
-- {{first_name}} {{last_name}}
-  - {{age}}
-  - Chore: {{chore}}
-  - Lodging: {{ lodging }}
-  - \${{pricing_result.total}}
+
+**{{first_name}} {{last_name}}, {{age}}**
+
+{{phone}}    
+{{email}}    
+Meals: {{meal_type}}{{#meal_exceptions}}, {{.}}{{/meal_exceptions}}    
+Registered for {{#attendance}}, {{.}}{{/attendance}}    
+Please arrive after 2pm on your first day.    
+Housing: {{lodging.lodging_requested.name}}    
+Sheet Rental: {{linens}}    
+Campership request: \${{campership_request}}    
+
+------
 {{/campers}}
 
-Donation to Lark Traditional Arts - \${{ pricing_results.donation }}
+Total fees: \${{pricing_results.tuition}}    
+Total campership donation: \${{pricing_results.campership_donation}}    
 
-TOTAL DUE: \${{pricing_results.total}}
+TOTAL FOR THIS REGISTRATION: \${{pricing_results.total}}    
 
-You chose to pay by {{registration.payment_type}}
+You have elected to pay by {{registration.payment_type}}.
 
-If you're paying by check, please make it for \${{pricing_results.total}} payable to "Lark Traditional Arts", and mail it to:
+If you are paying by check, make your check for **\${{pricing_results.total}}**
+payable to SFFMC and mail to:
 
-Lark Traditional Arts    
-PO Box 1724    
-Mendocino, CA 95460    
-USA    
+SFFMC, c/o Ellen Eagan
+149 Santa Maria Avenue
+San Bruno CA 94066
 
-Do you have questions? Email us at registration@larkcamp.org or call 707-397-5275
+If you would like to sign up to lead a workshop, you may do so on the [Workshop Signup Thread](https://docs.google.com/forms/d/e/1FAIpQLSfe9LwY1nBqNPan8QE6lcndFJsTJpnTL3fbwK1BKFNsyumEWA/viewform?vc=0&c=0&w=1&flr=0)
+
+You have agreed to Camp Harmony's Covid policy [link] and you will need to provide proof of a negative Covid test upon entering Camp.
+
+You will be receiving an email with your housing assignment and additional details by December 4. Thank you for registering for Camp Harmony!
 
 Registration Number: ${yearDisplay}CH{{ registration.id }}
 `;

--- a/data/harmony/preSubmitTemplate.js
+++ b/data/harmony/preSubmitTemplate.js
@@ -1,4 +1,3 @@
 export default `
-By submitting this form, you agree to the
-[Terms of Registration](https://docs.google.com/document/d/1pq2i2rHpHnsoB8kqtpH7FFn50JA-XELaRRMHh4hdTFg/edit?usp=sharing)
+By submitting this form, you agree to the [SFFMC Etiquette document](https://docs.google.com/document/d/1SFptLv4V84lso9yqTWT49s__W3elnUQn/edit?usp=sharing&ouid=112175546889387017762&rtpof=true&sd=true)
 `;

--- a/data/harmony/pricing/camperPricingLogic.js
+++ b/data/harmony/pricing/camperPricingLogic.js
@@ -92,6 +92,19 @@ const calculateCampership = {
   ]
 };
 
+const calculateLinens = {
+  '*': [
+    {
+      'if': [
+        {'===' : [{ var: 'camper.linens' }, 'Yes']},
+        1, 0,
+      ],
+    },
+    25
+  ]
+};
+
+
 const rate = (lodgingIds) => ({
   'if': [
     { '<': [{var: 'registration.created_at.epoch'}, cutoff] },
@@ -114,11 +127,16 @@ export default (lodgingIds) => [
     exp: { '*': [{ var: 'rate' }, dayCount] },
   },
   {
+    var: 'linens',
+    exp: calculateLinens,
+  },
+  {
     var: 'total',
     exp: {
-      '-': [
+      '+': [
         {var: 'tuition'},
-        {var: 'campership'},
+        { '*': [ {var: 'campership'}, -1 ] },
+        {var: 'linens'},
       ]
     }
   }

--- a/data/harmony/pricing/camperPricingLogic.js
+++ b/data/harmony/pricing/camperPricingLogic.js
@@ -81,7 +81,12 @@ const calculateCampershipRate = ({
 
 const calculateCampership = {
   min: [
-    { var: 'camper.campership_request' },
+    {
+      'or': [
+        { var: 'camper.campership_request' },
+        0,
+      ],
+    },
     { '/': [ { '*': [dayCount, calculateCampershipRate] }, 2] },
     300
   ]

--- a/data/harmony/registrationSchema.js
+++ b/data/harmony/registrationSchema.js
@@ -13,6 +13,8 @@ All Campers will need to test before arriving at Camp.
 **LODGING**    
 
 [Click here to see 2023-24 rates](https://docs.google.com/spreadsheets/d/1UvAbUg8KC5nCQWtYNe_V5Jecb3OtHC3lrn-_nBYHKxI/edit?usp=sharing) for lodging (all prices include meals)
+
+Fields marked with an asterisk (*) are required
 `,
   'type': 'object',
   'definitions': {

--- a/data/harmony/registrationSchema.js
+++ b/data/harmony/registrationSchema.js
@@ -41,12 +41,16 @@ All Campers will need to test before arriving at Camp.
     },
     'membership_check': {
       'title': 'SFFMC Membership',
-      'description': `San Francisco Folk Club Membership is required to attend Camp Harmony.
-To verify that your registration is current, please
-[click here](https://www.sffmc.org/log-in/?redirect_to=https%3A%2F%2Fwww.sffmc.org%2Fmembership-account%2F)
-and follow prompts to request a password.  Once you are logged into the site
-you will see your membership level and expiration date.  If you are new to the
-Folk Club, click “become a member” under the “Join Us!” tab.  Please verify that you are a member
+      'description': `Current San Francisco Folk Music Club membership is
+required to attend Camp Harmony.  Please verify that you are a current member
+by [clicking here](https://www.sffmc.org/log-in/?redirect_to=https%3A%2F%2Fwww.sffmc.org%2Fmembership-account%2F)
+to log into the site to check your expiration or auto-renew date.  If you don't
+know your password or haven't logged in before, click the "Lost Password" link
+to request a new password.  If you believe you are a member but are unable to
+log in even after requesting a new password, contact SFFMC membership secretary
+Ellen Eagan at [membership@sffmc.org](mailto:membership@sffmc.org) for
+assistance.  If you are new to the Folk Club, join us by clicking “become a
+member” under the “Join Us!” tab.
 `,
       'type': 'string',
       'enum': [

--- a/data/harmony/registrationUISchema.js
+++ b/data/harmony/registrationUISchema.js
@@ -25,6 +25,7 @@ export default {
         'email',
         'phone',
         'lodging',
+        'linens',
         'attendance',
         'meal_type',
         'meal_exceptions',

--- a/data/harmony/testRegistrations.js
+++ b/data/harmony/testRegistrations.js
@@ -79,6 +79,7 @@ function destructureCamper(c, email, phone, lodgingMap) {
     },
     attendance: days.slice(0, daycnt),
     campership_request: 0,
+    linens: 'No',
   };
 }
 


### PR DESCRIPTION
- Fix #419 - harmony preSubmit template
- Fix #431 - Membership portion of reg form
- Fix #428 - make campership request optional
- Fix #432 - Add linens to camp harmony
- Fix #427 - Note required fields
- Fix #415 - Update harmony confirmation email